### PR TITLE
Add cache for prepared statements

### DIFF
--- a/src/DbPdoDriver.php
+++ b/src/DbPdoDriver.php
@@ -22,6 +22,8 @@ abstract class DbPdoDriver implements DbDriverInterface
      */
     protected $stmtCache = [];
 
+    protected $maxStmtCache = 10;
+
     protected $supportMultRowset = false;
 
     /**
@@ -104,6 +106,7 @@ abstract class DbPdoDriver implements DbDriverInterface
     public function __destruct()
     {
         $this->instance = null;
+        $this->stmtCache = null;
     }
 
     /**
@@ -118,6 +121,9 @@ abstract class DbPdoDriver implements DbDriverInterface
 
         if (!isset($this->stmtCache[$sql])) {
             $this->stmtCache[$sql] = $this->instance->prepare($sql);
+            if (count($this->stmtCache) > $this->getMaxStmtCache()) { //Kill old cache to get waste memory
+                array_shift($this->stmtCache);
+            }
         }
 
         $stmt = $this->stmtCache[$sql];
@@ -253,5 +259,21 @@ abstract class DbPdoDriver implements DbDriverInterface
     public function setSupportMultRowset($multipleRowSet)
     {
         $this->supportMultRowset = $multipleRowSet;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMaxStmtCache()
+    {
+        return $this->maxStmtCache;
+    }
+
+    /**
+     * @param int $maxStmtCache
+     */
+    public function setMaxStmtCache($maxStmtCache)
+    {
+        $this->maxStmtCache = $maxStmtCache;
     }
 }

--- a/src/DbPdoDriver.php
+++ b/src/DbPdoDriver.php
@@ -34,10 +34,10 @@ abstract class DbPdoDriver implements DbDriverInterface
     /**
      * DbPdoDriver constructor.
      *
-     * @param \ByJG\Util\Uri $connUri
+     * @param Uri $connUri
      * @param null $preOptions
      * @param null $postOptions
-     * @throws \ByJG\AnyDataset\Core\Exception\NotAvailableException
+     * @throws NotAvailableException
      */
     public function __construct(Uri $connUri, $preOptions = null, $postOptions = null)
     {
@@ -105,8 +105,8 @@ abstract class DbPdoDriver implements DbDriverInterface
     
     public function __destruct()
     {
-        $this->instance = null;
         $this->stmtCache = null;
+        $this->instance = null;
     }
 
     /**

--- a/src/DbPdoDriver.php
+++ b/src/DbPdoDriver.php
@@ -119,7 +119,7 @@ abstract class DbPdoDriver implements DbDriverInterface
     {
         list($sql, $array) = SqlBind::parseSQL($this->connectionUri, $sql, $array);
 
-        if (!isset($this->stmtCache[$sql])) {
+        if ($this->getMaxStmtCache() > 0 && !isset($this->stmtCache[$sql])) {
             $this->stmtCache[$sql] = $this->instance->prepare($sql);
             if (count($this->stmtCache) > $this->getMaxStmtCache()) { //Kill old cache to get waste memory
                 array_shift($this->stmtCache);

--- a/src/DbPdoDriver.php
+++ b/src/DbPdoDriver.php
@@ -17,6 +17,11 @@ abstract class DbPdoDriver implements DbDriverInterface
      */
     protected $instance = null;
 
+    /**
+     * @var PDOStatement[]
+     */
+    protected $stmtCache = [];
+
     protected $supportMultRowset = false;
 
     /**
@@ -111,7 +116,11 @@ abstract class DbPdoDriver implements DbDriverInterface
     {
         list($sql, $array) = SqlBind::parseSQL($this->connectionUri, $sql, $array);
 
-        $stmt = $this->instance->prepare($sql);
+        if (!isset($this->stmtCache[$sql])) {
+            $this->stmtCache[$sql] = $this->instance->prepare($sql);
+        }
+
+        $stmt = $this->stmtCache[$sql];
 
         if (!empty($array)) {
             foreach ($array as $key => $value) {


### PR DESCRIPTION
Anydataset DB uses PDO prepared statements. That is a good practice because avoid security issues e.g. SQL Injection and can improve the execution performance if the prepared statement is reused. 

This PR enables to cache the prepared statements and reuse it. It means that Anydataset DB can benefit from the execution performance. 

Thanks to Florian Levis on issue #1 