### PR TITLE
Add sql_server driver

### DIFF
--- a/.idea/runConfigurations/Run_database_services_for_test.xml
+++ b/.idea/runConfigurations/Run_database_services_for_test.xml
@@ -7,6 +7,7 @@
           <list>
             <option value="postgres" />
             <option value="mysql" />
+            <option value="mssql" />
           </list>
         </option>
         <option name="sourceFilePath" value="docker-compose.yml" />

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,5 +29,6 @@ jobs:
   include:
     - stage: documentation
       if: branch = master
+      before_install: skip
       install: skip
       script: "curl https://opensource.byjg.com/add-doc.sh | bash /dev/stdin php anydataset-db"

--- a/README.md
+++ b/README.md
@@ -235,6 +235,36 @@ $filter->addRelation('field', \ByJG\AnyDataset\Core\Enum\Relation::EQUAL, $liter
 ```
 
 
+## FreeDTS / DBlib Date format Issues
+
+Date has the format `"Jul 27 2016 22:00:00.860"`. The solution is:
+
+Follow the solution:
+https://stackoverflow.com/questions/38615458/freetds-dateformat-issues
+
+## Generic PDO configuration
+
+The generic PDO driver uses the format `pdo://username:password@pdo_driver?dsn=<LITERAL PDO DSN>` and only need to be
+used for drivers are not mapped into the `anydataset-db` library.
+
+Let's say we want to connect with the PDO Interbase/Firebase database. 
+After install the PDO properly we need to create the connection string URI. 
+
+According to the Firebase documentation the PDO DSN is: 
+
+```text
+firebird:User=john;Password=mypass;Database=DATABASE.GDE;DataSource=localhost;Port=3050
+```
+
+and adapting to URI style we remove the information about the driver, user and password. Then we have:
+
+```php
+$uri = new \ByJG\Util\Uri("pdo://john:mypass@firebird?dsn=" . url_encode('Database=DATABASE.GDE;DataSource=localhost;Port=3050'));
+```
+
+Don't forget we need to `url_encode` the DSN parameter.
+
+
 ## Install
 
 Just type: 
@@ -262,7 +292,6 @@ docker-compose up -d postgres mysql
 ```
 
 **Run the tests**
-
 
 ```
 phpunit testsdb/PdoMySqlTest.php 

--- a/README.md
+++ b/README.md
@@ -27,14 +27,15 @@ See below the current implemented drivers:
 
 {:.table}
 
-| Database      | Connection String                                     | Factory
-| ------------- | ----------------------------------------------------- | -------------------------  |
-| Sqlite        | sqlite:///path/to/file                                | getDbRelationalInstance()  |
-| MySql/MariaDb | mysql://username:password@hostname:port/database      | getDbRelationalInstance()  |
-| Postgres      | psql://username:password@hostname:port/database       | getDbRelationalInstance()  |
-| Sql Server    | dblib://username:password@hostname:port/database      | getDbRelationalInstance()  |
-| Oracle (OCI)  | oci://username:password@hostname:port/database        | getDbRelationalInstance()  |
-| Oracle (OCI8) | oci8://username:password@hostname:port/database       | getDbRelationalInstance()  |
+| Database           | Connection String                                        | Factory
+| ------------------ | -------------------------------------------------------- | -------------------------  |
+| Sqlite             | sqlite:///path/to/file                                   | getDbRelationalInstance()  |
+| MySql/MariaDb      | mysql://username:password@hostname:port/database         | getDbRelationalInstance()  |
+| Postgres           | psql://username:password@hostname:port/database          | getDbRelationalInstance()  |
+| Sql Server (DbLib) | dblib://username:password@hostname:port/database         | getDbRelationalInstance()  |
+| Oracle (OCI)       | oci://username:password@hostname:port/database           | getDbRelationalInstance()  |
+| Oracle (OCI8)      | oci8://username:password@hostname:port/database          | getDbRelationalInstance()  |
+| Generic PDO        | pdo://username:password@pdo_driver?dsn=<LITERAL PDO DSN> | getDbRelationalInstance()  |
 
 ```php
 <?php

--- a/README.md
+++ b/README.md
@@ -27,15 +27,16 @@ See below the current implemented drivers:
 
 {:.table}
 
-| Database           | Connection String                                        | Factory
-| ------------------ | -------------------------------------------------------- | -------------------------  |
-| Sqlite             | sqlite:///path/to/file                                   | getDbRelationalInstance()  |
-| MySql/MariaDb      | mysql://username:password@hostname:port/database         | getDbRelationalInstance()  |
-| Postgres           | psql://username:password@hostname:port/database          | getDbRelationalInstance()  |
-| Sql Server (DbLib) | dblib://username:password@hostname:port/database         | getDbRelationalInstance()  |
-| Oracle (OCI)       | oci://username:password@hostname:port/database           | getDbRelationalInstance()  |
-| Oracle (OCI8)      | oci8://username:password@hostname:port/database          | getDbRelationalInstance()  |
-| Generic PDO        | pdo://username:password@pdo_driver?dsn=<LITERAL PDO DSN> | getDbRelationalInstance()  |
+| Database            | Connection String                                        | Factory
+| ------------------- | -------------------------------------------------------- | -------------------------  |
+| Sqlite              | sqlite:///path/to/file                                   | getDbRelationalInstance()  |
+| MySql/MariaDb       | mysql://username:password@hostname:port/database         | getDbRelationalInstance()  |
+| Postgres            | psql://username:password@hostname:port/database          | getDbRelationalInstance()  |
+| Sql Server (DbLib)  | dblib://username:password@hostname:port/database         | getDbRelationalInstance()  |
+| Sql Server (Sqlsrv) | sqlsrv://username:password@hostname:port/database        | getDbRelationalInstance()  |
+| Oracle (OCI)        | oci://username:password@hostname:port/database           | getDbRelationalInstance()  |
+| Oracle (OCI8)       | oci8://username:password@hostname:port/database          | getDbRelationalInstance()  |
+| Generic PDO         | pdo://username:password@pdo_driver?dsn=<LITERAL PDO DSN> | getDbRelationalInstance()  |
 
 ```php
 <?php

--- a/src/DbPdoDriver.php
+++ b/src/DbPdoDriver.php
@@ -43,19 +43,7 @@ abstract class DbPdoDriver implements DbDriverInterface
      */
     public function __construct(Uri $connUri, $preOptions = null, $postOptions = null)
     {
-        $this->connectionUri = $connUri;
-
-        if (!defined('PDO::ATTR_DRIVER_NAME')) {
-            throw new NotAvailableException("Extension 'PDO' is not loaded");
-        }
-
-        if (!extension_loaded('pdo_' . strtolower($connUri->getScheme()))) {
-            throw new NotAvailableException("Extension 'pdo_" . strtolower($connUri->getScheme()) . "' is not loaded");
-        }
-
-        if ($connUri->getQueryPart("stmtcache") == "true") {
-            $this->useStmtCache = true;
-        }
+        $this->validateConnUri($connUri);
 
         $strcnn = $this->createPboConnStr($connUri);
 
@@ -74,6 +62,37 @@ abstract class DbPdoDriver implements DbDriverInterface
 
         $this->connectionUri = $this->connectionUri->withScheme($this->instance->getAttribute(PDO::ATTR_DRIVER_NAME));
 
+        $this->setPdoDefaultParams($postOptions);
+    }
+
+    /**
+     * @param Uri $connUri
+     * @param null $scheme
+     * @throws NotAvailableException
+     */
+    protected function validateConnUri($connUri, $scheme = null)
+    {
+        $this->connectionUri = $connUri;
+
+        if (!defined('PDO::ATTR_DRIVER_NAME')) {
+            throw new NotAvailableException("Extension 'PDO' is not loaded");
+        }
+
+        if (empty($scheme)) {
+            $scheme = $connUri->getScheme();
+        }
+
+        if (!extension_loaded('pdo_' . strtolower($scheme))) {
+            throw new NotAvailableException("Extension 'pdo_" . strtolower($connUri->getScheme()) . "' is not loaded");
+        }
+
+        if ($connUri->getQueryPart("stmtcache") == "true") {
+            $this->useStmtCache = true;
+        }
+    }
+
+    protected function setPdoDefaultParams($postOptions = [])
+    {
         // Set Specific Attributes
         $this->instance->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $this->instance->setAttribute(PDO::ATTR_CASE, PDO::CASE_LOWER);

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -31,6 +31,7 @@ class Factory
             [
                 "oci8" => $prefix . "DbOci8Driver",
                 "dblib" => $prefix . "PdoDblib",
+                "sqlsrv" => $prefix . "PdoSqlsrv",
                 "mysql" => $prefix . "PdoMysql",
                 "pgsql" => $prefix . "PdoPgsql",
                 "oci" => $prefix . "PdoOci",
@@ -41,7 +42,11 @@ class Factory
             (array)$schemesAlternative
         );
 
-        $class = isset($validSchemes[$scheme]) ? $validSchemes[$scheme] : PdoLiteral::class;
+        if (!isset($validSchemes[$scheme])) {
+            throw new \InvalidArgumentException("The '$scheme' scheme does not exist. Check the scheme name or use the Generic PDO scheme");
+        }
+
+        $class = $validSchemes[$scheme];
 
         $instance = new $class($connectionUri);
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -36,6 +36,7 @@ class Factory
                 "oci" => $prefix . "PdoOci",
                 "odbc" => $prefix . "PdoOdbc",
                 "sqlite" => $prefix . "PdoSqlite",
+                "pdo" => $prefix . "PdoPdo"
             ],
             (array)$schemesAlternative
         );

--- a/src/Helpers/DbBaseFunctions.php
+++ b/src/Helpers/DbBaseFunctions.php
@@ -138,7 +138,7 @@ abstract class DbBaseFunctions implements DbFunctionsInterface
     {
         $dbdataset->execute($sql, $param);
 
-        return -1;
+        return $dbdataset->getDbConnection()->lastInsertId();
     }
 
     protected $deliFieldLeft = '';

--- a/src/Helpers/DbPdoFunctions.php
+++ b/src/Helpers/DbPdoFunctions.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace ByJG\AnyDataset\Db\Helpers;
+
+use ByJG\AnyDataset\Db\DbDriverInterface;
+
+class DbPdoFunctions extends DbBaseFunctions
+{
+
+    public function __construct()
+    {
+        $this->deliFieldLeft = '';
+        $this->deliFieldRight = '';
+        $this->deliTableLeft = '';
+        $this->deliTableRight = '';
+    }
+
+    public function concat($str1, $str2 = null)
+    {
+        return null;
+    }
+
+    /**
+     * Given a SQL returns it with the proper LIMIT or equivalent method included
+     * @param string $sql
+     * @param int $start
+     * @param int $qty
+     * @return string
+     */
+    public function limit($sql, $start, $qty = null)
+    {
+        return null;
+    }
+
+    /**
+     * Given a SQL returns it with the proper TOP or equivalent method included
+     * @param string $sql
+     * @param int $qty
+     * @return string
+     */
+    public function top($sql, $qty)
+    {
+        return null;
+    }
+
+    /**
+     * Return if the database provider have a top or similar function
+     * @return bool
+     */
+    public function hasTop()
+    {
+        return false;
+    }
+
+    /**
+     * Return if the database provider have a limit function
+     * @return bool
+     */
+    public function hasLimit()
+    {
+        return false;
+    }
+
+    /**
+     * Format date column in sql string given an input format that understands Y M D
+     *
+     * @param string $format
+     * @param string|null $column
+     * @return string
+     * @example $db->getDbFunctions()->SQLDate("d/m/Y H:i", "dtcriacao")
+     */
+    public function sqlDate($format, $column = null)
+    {
+        return null;
+    }
+
+    public function hasForUpdate()
+    {
+        return false;
+    }
+}

--- a/src/Helpers/DbSqlsrvFunctions.php
+++ b/src/Helpers/DbSqlsrvFunctions.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace ByJG\AnyDataset\Db\Helpers;
+
+use ByJG\AnyDataset\Db\DbDriverInterface;
+use ByJG\AnyDataset\Core\Exception\NotAvailableException;
+
+class DbSqlsrvFunctions extends DbDblibFunctions
+{
+
+    /**
+     * DbSqlsrvFunctions constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+}

--- a/src/PdoPdo.php
+++ b/src/PdoPdo.php
@@ -2,7 +2,9 @@
 
 namespace ByJG\AnyDataset\Db;
 
+use ByJG\AnyDataset\Core\Exception\NotAvailableException;
 use ByJG\Util\Uri;
+use PDO;
 
 class PdoPdo extends DbPdoDriver
 {
@@ -10,12 +12,12 @@ class PdoPdo extends DbPdoDriver
     /**
      * PdoPdo constructor.
      *
-     * @param \ByJG\Util\Uri $connUri
-     * @throws \ByJG\AnyDataset\Core\Exception\NotAvailableException
+     * @param Uri $connUri
+     * @throws NotAvailableException
      */
     public function __construct(Uri $connUri, $preOptions = [], $postOptions = [])
     {
-        $this->connectionUri = $connUri;
+        $this->validateConnUri($connUri, $connUri->getHost());
 
         if (empty($connUri->getQueryPart("dsn"))) {
             throw new \InvalidArgumentException("The generic PDO Driver requires the `dsn` argument");
@@ -23,10 +25,8 @@ class PdoPdo extends DbPdoDriver
 
         $dsn = $connUri->getHost() . ":" . $connUri->getQueryPart("dsn");
 
-        $this->instance = new \PDO($dsn, $connUri->getUsername(), $connUri->getPassword(), $preOptions);
+        $this->instance = new PDO($dsn, $connUri->getUsername(), $connUri->getPassword(), $preOptions);
 
-        foreach ((array) $postOptions as $key => $value) {
-            $this->instance->setAttribute($key, $value);
-        }
+        $this->setPdoDefaultParams($postOptions);
     }
 }

--- a/src/PdoPdo.php
+++ b/src/PdoPdo.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace ByJG\AnyDataset\Db;
+
+use ByJG\Util\Uri;
+
+class PdoPdo extends DbPdoDriver
+{
+
+    /**
+     * PdoPdo constructor.
+     *
+     * @param \ByJG\Util\Uri $connUri
+     * @throws \ByJG\AnyDataset\Core\Exception\NotAvailableException
+     */
+    public function __construct(Uri $connUri, $preOptions = [], $postOptions = [])
+    {
+        $this->connectionUri = $connUri;
+
+        if (empty($connUri->getQueryPart("dsn"))) {
+            throw new \InvalidArgumentException("The generic PDO Driver requires the `dsn` argument");
+        }
+
+        $dsn = $connUri->getHost() . ":" . $connUri->getQueryPart("dsn");
+
+        $this->instance = new \PDO($dsn, $connUri->getUsername(), $connUri->getPassword(), $preOptions);
+
+        foreach ((array) $postOptions as $key => $value) {
+            $this->instance->setAttribute($key, $value);
+        }
+    }
+}

--- a/src/PdoSqlsrv.php
+++ b/src/PdoSqlsrv.php
@@ -4,21 +4,30 @@ namespace ByJG\AnyDataset\Db;
 
 use ByJG\AnyDataset\Core\Exception\NotAvailableException;
 use ByJG\Util\Uri;
+use PDO;
 
-class PdoDblib extends DbPdoDriver
+class PdoSqlsrv extends PdoDblib
 {
 
     /**
-     * PdoDblib constructor.
+     * PdoSqlsrv constructor.
      *
      * @param Uri $connUri
-     * @throws NotAvailableException
+     * @throws \ByJG\AnyDataset\Core\Exception\NotAvailableException
      */
     public function __construct($connUri)
     {
         $this->setSupportMultRowset(true);
 
-        parent::__construct($connUri, null, null);
+        $this->validateConnUri($connUri);
+
+        $dsn = $connUri->getScheme() . ":"
+            . "server=" . $connUri->getHost() . (!empty($connUri->getPort()) ? "," . $connUri->getPort() : "") . ";"
+            . "Database=" . preg_replace('~^/~', '', $connUri->getPath());
+
+        $this->instance = new PDO($dsn, $connUri->getUsername(), $connUri->getPassword());
+
+        $this->setPdoDefaultParams();
 
         // Solve the error:
         // SQLSTATE[HY000]: General error: 1934 General SQL Server error: Check messages from the SQL Server [1934]

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use ByJG\AnyDataset\Db\Factory;
+use PHPUnit\Framework\TestCase;
+
+class FactoryTest extends TestCase
+{
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage 'abc' scheme does not exist
+     */
+    public function testNonExistentScheme()
+    {
+        Factory::getDbRelationalInstance("abc://user:pass@test");
+    }
+}

--- a/tests/Helpers/DbDblibFunctionsTest.php
+++ b/tests/Helpers/DbDblibFunctionsTest.php
@@ -10,7 +10,7 @@ class DbDblibFunctionsTest extends TestCase
     /**
      * @var DbDblibFunctions
      */
-    private $object;
+    protected $object;
 
     protected function setUp()
     {

--- a/tests/Helpers/DbSqlsrvFunctionsTest.php
+++ b/tests/Helpers/DbSqlsrvFunctionsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\AnyDataset\Store\Helpers;
+
+use ByJG\AnyDataset\Db\Helpers\DbDblibFunctions;
+use ByJG\AnyDataset\Db\Helpers\DbSqlsrvFunctions;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . "/DbDblibFunctionsTest.php";
+
+class DbSqlsrvFunctionsTest extends DbDblibFunctionsTest
+{
+    protected function setUp()
+    {
+        $this->object = new DbSqlsrvFunctions();
+    }
+}

--- a/tests/PdoLiteralTest.php
+++ b/tests/PdoLiteralTest.php
@@ -29,4 +29,9 @@ class PdoLiteralTest extends BasePdo
     {
         $this->markTestSkipped('SqlLite does not have this method');
     }
+
+    public function testGetDate()
+    {
+        $this->markTestSkipped('Do not use here');
+    }
 }

--- a/testsdb/BasePdo.php
+++ b/testsdb/BasePdo.php
@@ -331,5 +331,9 @@ abstract class BasePdo extends TestCase
         );
     }
 
+    public function testGetDate() {
+        throw new NotImplementedException("Needs to be implemented for each database");
+    }
+
 }
 

--- a/testsdb/PdoDblibTest.php
+++ b/testsdb/PdoDblibTest.php
@@ -33,4 +33,13 @@ class PdoDblibTest extends BasePdo
     {
         $this->dbDriver->execute('drop table Dogs;');
     }
+
+    public function testGetDate() {
+        $data = $this->dbDriver->getScalar("SELECT CONVERT(date, '2018-07-26 20:02:03') ");
+        $this->assertEquals("2018-07-26 00:00:00", $data);
+
+        $data = $this->dbDriver->getScalar("SELECT CONVERT(datetime, '2018-07-26 20:02:03') ");
+        $this->assertEquals("2018-07-26 20:02:03", $data);
+    }
+
 }

--- a/testsdb/PdoMySqlTest.php
+++ b/testsdb/PdoMySqlTest.php
@@ -6,7 +6,7 @@ use ByJG\AnyDataset\Db\Factory;
 
 require_once 'BasePdo.php';
 
-class PdoMySqlest extends BasePdo
+class PdoMySqlTest extends BasePdo
 {
 
     protected function createInstance()
@@ -39,5 +39,13 @@ class PdoMySqlest extends BasePdo
     public function deleteDatabase()
     {
         $this->dbDriver->execute('drop table Dogs;');
+    }
+
+    public function testGetDate() {
+        $data = $this->dbDriver->getScalar("SELECT CONVERT('2018-07-26 20:02:03', date) ");
+        $this->assertEquals("2018-07-26", $data);
+
+        $data = $this->dbDriver->getScalar("SELECT CONVERT('2018-07-26 20:02:03', datetime) ");
+        $this->assertEquals("2018-07-26 20:02:03", $data);
     }
 }

--- a/testsdb/PdoPdoTest.php
+++ b/testsdb/PdoPdoTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace TestsDb\AnyDataset;
+
+use ByJG\AnyDataset\Db\Factory;
+
+require_once 'PdoPostgresTest.php';
+
+class PdoPdoTest extends PdoPostgresTest
+{
+
+    protected function createInstance()
+    {
+        $host = getenv('PSQL_TEST_HOST');
+        if (empty($host)) {
+            $host = "127.0.0.1";
+        }
+        $password = getenv('PSQL_PASSWORD');
+        if (empty($password)) {
+            $password = 'password';
+        }
+        if ($password == '.') {
+            $password = "";
+        }
+
+        $pdoConn = "host=$host";
+        $this->dbDriver = Factory::getDbRelationalInstance("pdo://postgres:$password@pgsql?dsn=" . urlencode($pdoConn));
+
+        $exists = $this->dbDriver->getScalar('select count(1) from pg_catalog.pg_database where datname = \'testpdo\'');
+        if ($exists == 0) {
+            $this->dbDriver->execute('CREATE DATABASE testpdo');
+        }
+
+        $pdoConn = "$pdoConn;dbname=testpdo;";
+        $this->dbDriver = Factory::getDbRelationalInstance("pdo://postgres:$password@pgsql?dsn=" . urlencode($pdoConn));
+    }
+}

--- a/testsdb/PdoPostgresTest.php
+++ b/testsdb/PdoPostgresTest.php
@@ -41,4 +41,12 @@ class PdoPostgresTest extends BasePdo
     {
         $this->dbDriver->execute('drop table Dogs;');
     }
+
+    public function testGetDate() {
+        $data = $this->dbDriver->getScalar("SELECT CAST('2018-07-26' AS DATE) ");
+        $this->assertEquals("2018-07-26", $data);
+
+        $data = $this->dbDriver->getScalar("SELECT CAST('2018-07-26 20:02:03' AS TIMESTAMP) ");
+        $this->assertEquals("2018-07-26 20:02:03", $data);
+    }
 }

--- a/testsdb/PdoSqliteTest.php
+++ b/testsdb/PdoSqliteTest.php
@@ -62,4 +62,13 @@ class PdoSqliteTest extends BasePdo
         $this->assertEquals(10, $this->dbDriver->getCountStmtCache()); // because of createDatabase() and populateData()
         $this->assertEquals([["name" => 30]], $it->toArray());
     }
+
+    public function testGetDate() {
+        $data = $this->dbDriver->getScalar("SELECT DATE('2018-07-26') ");
+        $this->assertEquals("2018-07-26", $data);
+
+        $data = $this->dbDriver->getScalar("SELECT DATETIME('2018-07-26 20:02:03') ");
+        $this->assertEquals("2018-07-26 20:02:03", $data);
+    }
+
 }

--- a/testsdb/PdoSqlsrvTest.php
+++ b/testsdb/PdoSqlsrvTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace TestsDb\AnyDataset;
+
+use ByJG\AnyDataset\Db\Factory;
+
+require_once 'PdoDblibTest.php';
+
+class PdoSqlsrvTest extends PdoDblibTest
+{
+
+    protected function createInstance()
+    {
+        $host = getenv('MSSQL_TEST_HOST');
+        if (empty($host)) {
+            $host = "127.0.0.1";
+        }
+        $password = getenv('MSSQL_PASSWORD');
+        if (empty($password)) {
+            $password = 'Pa55word';
+        }
+
+        $this->dbDriver = Factory::getDbRelationalInstance("sqlsrv://sa:$password@$host/tempdb");
+    }
+}

--- a/testsdb/PdoSqlsrvTest.php
+++ b/testsdb/PdoSqlsrvTest.php
@@ -22,4 +22,12 @@ class PdoSqlsrvTest extends PdoDblibTest
 
         $this->dbDriver = Factory::getDbRelationalInstance("sqlsrv://sa:$password@$host/tempdb");
     }
+
+    public function testGetDate() {
+        $data = $this->dbDriver->getScalar("SELECT CONVERT(date, '2018-07-26 20:02:03') ");
+        $this->assertEquals("2018-07-26", $data);
+
+        $data = $this->dbDriver->getScalar("SELECT CONVERT(datetime, '2018-07-26 20:02:03') ");
+        $this->assertEquals("2018-07-26 20:02:03.000", $data);
+    }
 }


### PR DESCRIPTION
Added Microsoft Sql Server driver using the connector `sqlsrv_connect` https://docs.microsoft.com/en-us/sql/connect/php/installation-tutorial-linux-mac?view=sql-server-ver15 to support PR https://github.com/byjg/migration/issues/33 

```
sqlsrv://username:password@hostname:port/database
```

Dblib still can be used as:

```
dblib://username:password@hostname:port/database 
```