### PR TITLE
Add executor observers and Journal for recording/restoring DML operations (6.1.0)

### DIFF
--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -1,0 +1,404 @@
+# Changelog - Version 6.0
+
+## Overview
+
+Version 6.0 represents a major architectural refactoring of the AnyDataset-DB library, focusing on improved separation of concerns, enhanced type safety, and better code maintainability. This release introduces breaking changes that require migration from 5.x.
+
+## System Requirements
+
+### PHP Version
+- **Minimum:** PHP 8.3
+- **Maximum:** PHP 8.5
+- **Previous (5.x):** PHP 8.1 - 8.3
+
+### Dependency Updates
+- **byjg/uri:** ^6.0 (previously ^5.0)
+- **byjg/anydataset:** ^6.0 (previously ^5.0)
+- **byjg/cache-engine:** ^6.0 (previously ^5.0)
+- **PHPUnit:** ^10.5|^11.5|^12.3 (previously ^9.6)
+- **Psalm:** ^5.9|^6.13 (previously ^5.9)
+
+---
+
+## New Features
+
+### 1. DatabaseExecutor API
+A new high-level API for database operations that provides better separation of concerns:
+- Introduced `DatabaseExecutor` class as the recommended interface for query execution
+- Separates high-level query operations from low-level driver management
+- Improved testability and maintainability
+- Factory method: `DatabaseExecutor::using($dbDriver)`
+
+**Documentation:** [Database Executor](docs/database-executor.md)
+
+### 2. Enhanced SQL Dialect System
+Completely refactored the database-specific SQL dialect handling:
+- New `SqlDialectInterface` with improved type safety
+- Organized dialect classes under dedicated `SqlDialect\` namespace
+- Base class `BaseSqlDialect` provides common functionality
+- Database-specific dialects: `MysqlDialect`, `PgsqlDialect`, `SqliteDialect`, `DblibDialect`, `SqlsrvDialect`, `OciDialect`, `GenericPdoDialect`
+
+### 3. Parameter Binding System
+- New `ParameterBinder` class replaces legacy `SqlBind`
+- Improved parameter handling with better type safety
+- Enhanced consistency across database drivers
+- Support for explicit type casting (e.g., port values as strings)
+
+### 4. DatabaseRouter (Previously Route)
+- Enhanced routing capabilities with better driver management
+- Improved exception handling with new `RouteNotInitializedException`
+- More transparent routing with `DatabaseExecutor` integration
+- Better support for load balancing and connection pooling
+
+### 5. Iterator Convenience Methods
+New methods on database iterators for improved usability:
+- `first()` - Get the first record from results
+- `exists()` - Check if results contain any records
+- `toEntities()` - Convert results to entity objects
+
+**Documentation:** [Iterator Filter](docs/iteratorfilter.md)
+
+### 6. Multi-Rowset Support
+- New `processMultiRowset()` method for handling multiple result sets
+- Extended support for stored procedures returning multiple datasets
+- Database-specific implementations for optimal performance
+
+### 7. Entity Mapping Enhancements
+- Enhanced entity support in `SqlStatement`
+- Improved transformer integration
+- Better property handling with `PreFetchTrait` improvements
+- Merge entity properties with fetched data for complete processing
+
+**Documentation:** [Entity Mapping](docs/entity.md)
+
+### 8. Logging Support
+- PSR-3 logger integration across the library
+- Enhanced logging capabilities for debugging
+- Configurable log handlers
+
+**Documentation:** [Logging](docs/logging.md)
+
+### 9. Enhanced PostgreSQL Support
+- Improved double colon (::) handling
+- Better type casting support
+- Updated documentation
+
+**Documentation:** [PostgreSQL](docs/postgresql.md)
+
+### 10. Stricter Type Safety
+- Migration to nullable types in function signatures
+- Added `#[Override]` annotations for better IDE support
+- Enhanced runtime exception handling across all drivers
+- Improved null safety validation
+
+---
+
+## Bug Fixes
+
+- Fixed double colon (::) handling in PostgreSQL queries
+- Corrected parameter type handling in `PdoDblib` and `PdoSqlsrv` (explicit string casting for port values)
+- Resolved issues with parameter binding in `IteratorFilterSqlFormatter`
+- Fixed edge cases in `PreFetchTrait` property merging
+- Improved multi-rowset processing validation and error handling
+- Corrected `getSqlLastInsertId` logic across database-specific implementations
+
+---
+
+## Breaking Changes
+
+The following table outlines the breaking changes between version 5.x and 6.0:
+
+| Category | Before (5.x) | After (6.0) | Description |
+|----------|-------------|-------------|-------------|
+| **PHP Version** | PHP 8.1 - 8.3 | PHP 8.3 - 8.5 | Minimum PHP version increased to 8.3 |
+| **Query Execution** | `$dbDriver->getIterator($sql)` | `DatabaseExecutor::using($dbDriver)->getIterator($sql)` | Query methods moved from driver to executor |
+| **Interface Name** | `DbFunctionsInterface` | `SqlDialectInterface` | Renamed for clarity |
+| **Helper Classes** | `Helpers\DbMysqlFunctions` | `SqlDialect\MysqlDialect` | Renamed and relocated |
+| **Helper Classes** | `Helpers\DbPgsqlFunctions` | `SqlDialect\PgsqlDialect` | Renamed and relocated |
+| **Helper Classes** | `Helpers\DbSqliteFunctions` | `SqlDialect\SqliteDialect` | Renamed and relocated |
+| **Helper Classes** | `Helpers\DbDblibFunctions` | `SqlDialect\DblibDialect` | Renamed and relocated |
+| **Helper Classes** | `Helpers\DbSqlsrvFunctions` | `SqlDialect\SqlsrvDialect` | Renamed and relocated |
+| **Helper Classes** | `Helpers\DbOci8Functions` | `SqlDialect\OciDialect` | Renamed and relocated |
+| **Helper Classes** | `Helpers\DbPdoFunctions` | `SqlDialect\GenericPdoDialect` | Renamed and relocated |
+| **Base Helper** | `Helpers\DbBaseFunctions` | `SqlDialect\BaseSqlDialect` | Renamed and relocated |
+| **Router Class** | `Route` | `DatabaseRouter` | Renamed for clarity |
+| **Method Name** | `getDbHelper()` | `getSqlDialect()` | Returns `SqlDialectInterface` |
+| **Parameter Binding** | `SqlBind` | `ParameterBinder` | New parameter binding class |
+| **Driver Method** | `$dbDriver->execute($sql)` | `DatabaseExecutor::using($dbDriver)->execute($sql)` | Deprecated on driver (removed in 7.0) |
+| **Driver Method** | `$dbDriver->getScalar($sql)` | `DatabaseExecutor::using($dbDriver)->getScalar($sql)` | Deprecated on driver (removed in 7.0) |
+| **Driver Method** | `$dbDriver->getAllFields($table)` | `DatabaseExecutor::using($dbDriver)->getAllFields($table)` | Deprecated on driver (removed in 7.0) |
+| **Driver Method** | `$dbDriver->executeAndGetId($sql)` | `DatabaseExecutor::using($dbDriver)->executeAndGetId($sql)` | Deprecated on driver (removed in 7.0) |
+| **Dependencies** | byjg/uri: ^5.0 | byjg/uri: ^6.0 | Major version update |
+| **Dependencies** | byjg/anydataset: ^5.0 | byjg/anydataset: ^6.0 | Major version update |
+| **Dependencies** | byjg/cache-engine: ^5.0 | byjg/cache-engine: ^6.0 | Major version update |
+| **Testing** | PHPUnit ^9.6 | PHPUnit ^10.5\|^11.5\|^12.3 | Updated test framework |
+| **Test Annotations** | PHPDoc annotations | PHP 8+ attributes | Migrated to modern attributes |
+| **Namespace** | `ByJG\AnyDataset\Db\Helpers\*` | `ByJG\AnyDataset\Db\SqlDialect\*` | Namespace reorganization |
+
+---
+
+## Upgrade Path from 5.x to 6.0
+
+Follow these steps to migrate your application from version 5.x to 6.0:
+
+### Step 1: Update System Requirements
+
+Ensure your environment meets the new requirements:
+
+```bash
+# Check PHP version (must be >= 8.3)
+php -v
+```
+
+### Step 2: Update Composer Dependencies
+
+Update your `composer.json`:
+
+```json
+{
+  "require": {
+    "byjg/anydataset-db": "^6.0"
+  }
+}
+```
+
+Then run:
+
+```bash
+composer update byjg/anydataset-db
+```
+
+### Step 3: Migrate to DatabaseExecutor
+
+Replace direct query calls on drivers with `DatabaseExecutor`:
+
+**Before:**
+```php
+use ByJG\AnyDataset\Db\Factory;
+
+$dbDriver = Factory::getDbInstance('mysql://user:pass@host/db');
+$iterator = $dbDriver->getIterator('SELECT * FROM users');
+$count = $dbDriver->getScalar('SELECT COUNT(*) FROM users');
+$dbDriver->execute('UPDATE users SET active = 1');
+```
+
+**After:**
+```php
+use ByJG\AnyDataset\Db\Factory;
+use ByJG\AnyDataset\Db\DatabaseExecutor;
+
+$dbDriver = Factory::getDbInstance('mysql://user:pass@host/db');
+$executor = DatabaseExecutor::using($dbDriver);
+
+$iterator = $executor->getIterator('SELECT * FROM users');
+$count = $executor->getScalar('SELECT COUNT(*) FROM users');
+$executor->execute('UPDATE users SET active = 1');
+```
+
+### Step 4: Update Interface and Class References
+
+Replace old interface and class names:
+
+**Before:**
+```php
+use ByJG\AnyDataset\Db\DbFunctionsInterface;
+use ByJG\AnyDataset\Db\Helpers\DbMysqlFunctions;
+use ByJG\AnyDataset\Db\Route;
+
+function process(DbFunctionsInterface $helper) {
+    $sql = $helper->limit('SELECT * FROM users', 0, 10);
+}
+
+$route = new Route();
+```
+
+**After:**
+```php
+use ByJG\AnyDataset\Db\Interfaces\SqlDialectInterface;
+use ByJG\AnyDataset\Db\SqlDialect\MysqlDialect;
+use ByJG\AnyDataset\Db\DatabaseRouter;
+
+function process(SqlDialectInterface $dialect) {
+    $sql = $dialect->limit('SELECT * FROM users', 0, 10);
+}
+
+$router = new DatabaseRouter();
+```
+
+### Step 5: Update Method Calls
+
+Replace deprecated method names:
+
+**Before:**
+```php
+$helper = $dbDriver->getDbHelper();
+$sql = $helper->concat("'Hello '", "name");
+```
+
+**After:**
+```php
+$dialect = $dbDriver->getSqlDialect();
+$sql = $dialect->concat("'Hello '", "name");
+```
+
+### Step 6: Update Imports
+
+Find and replace namespace imports:
+
+```bash
+# Find old imports
+grep -r "use ByJG\\AnyDataset\\Db\\Helpers\\" --include="*.php" .
+
+# Replace with new namespace
+# Helpers\DbMysqlFunctions -> SqlDialect\MysqlDialect
+# Helpers\DbPgsqlFunctions -> SqlDialect\PgsqlDialect
+# etc.
+```
+
+### Step 7: Update Parameter Binding (if used directly)
+
+If you were using `SqlBind` directly:
+
+**Before:**
+```php
+use ByJG\AnyDataset\Db\Helpers\SqlBind;
+
+$sqlBind = new SqlBind($sql, $params);
+```
+
+**After:**
+```php
+use ByJG\AnyDataset\Db\ParameterBinder;
+
+$binder = new ParameterBinder($sql, $params);
+```
+
+### Step 8: Update Test Code
+
+If you have tests using PHPDoc annotations, migrate to attributes:
+
+**Before:**
+```php
+/**
+ * @dataProvider userProvider
+ */
+public function testUser($data) { }
+```
+
+**After:**
+```php
+#[DataProvider('userProvider')]
+public function testUser($data) { }
+```
+
+### Step 9: Review and Test
+
+1. Run your static analysis tools:
+   ```bash
+   vendor/bin/psalm
+   # or
+   vendor/bin/phpstan analyse
+   ```
+
+2. Run your test suite:
+   ```bash
+   vendor/bin/phpunit
+   ```
+
+3. Check for deprecation warnings in logs
+
+### Step 10: Update Documentation References
+
+Review your project documentation and update any references to:
+- Class names (Route → DatabaseRouter)
+- Method names (getDbHelper → getSqlDialect)
+- Code examples using the old API
+
+---
+
+## Deprecation Notices
+
+The following features are **deprecated in 6.0** and will be **removed in 7.0**:
+
+### Direct Query Methods on DbDriverInterface
+
+These methods still work in 6.0 but will be removed in 7.0:
+- `DbDriverInterface::getIterator()`
+- `DbDriverInterface::getScalar()`
+- `DbDriverInterface::getAllFields()`
+- `DbDriverInterface::execute()`
+- `DbDriverInterface::executeAndGetId()`
+
+**Action Required:** Migrate to `DatabaseExecutor` before upgrading to 7.0.
+
+**See:** [Deprecated Features Documentation](docs/deprecated-features.md)
+
+---
+
+## Migration Checklist
+
+Use this checklist to ensure complete migration:
+
+### Environment
+- [ ] Verify PHP version is 8.3 or higher
+- [ ] Update composer dependencies
+- [ ] Run `composer update`
+
+### Code Changes
+- [ ] Replace `$dbDriver->getIterator()` with `$executor->getIterator()`
+- [ ] Replace `$dbDriver->getScalar()` with `$executor->getScalar()`
+- [ ] Replace `$dbDriver->getAllFields()` with `$executor->getAllFields()`
+- [ ] Replace `$dbDriver->execute()` with `$executor->execute()`
+- [ ] Replace `$dbDriver->executeAndGetId()` with `$executor->executeAndGetId()`
+- [ ] Update `DbFunctionsInterface` → `SqlDialectInterface`
+- [ ] Update `getDbHelper()` → `getSqlDialect()`
+- [ ] Update namespace imports: `Helpers\*` → `SqlDialect\*`
+- [ ] Update class names: `Db*Functions` → `*Dialect`
+- [ ] Update `Route` → `DatabaseRouter`
+- [ ] Update `SqlBind` → `ParameterBinder` (if used directly)
+
+### Testing
+- [ ] Update PHPDoc annotations to attributes (if applicable)
+- [ ] Run static analysis (Psalm/PHPStan)
+- [ ] Run test suite
+- [ ] Check application logs for deprecation warnings
+- [ ] Test all database operations in staging environment
+
+### Documentation
+- [ ] Update code documentation
+- [ ] Update README/wiki if applicable
+- [ ] Update team documentation about API changes
+
+---
+
+## Additional Resources
+
+- [Getting Started Guide](docs/getting-started.md)
+- [DatabaseExecutor Documentation](docs/database-executor.md)
+- [Deprecated Features Guide](docs/deprecated-features.md)
+- [Database Driver Interface](docs/db-driver-interface.md)
+- [Entity Mapping](docs/entity.md)
+- [Load Balancing and Connection Pooling](docs/load-balance.md)
+
+---
+
+## Support
+
+If you encounter issues during migration:
+
+1. Review the [Deprecated Features Documentation](docs/deprecated-features.md)
+2. Check the [examples in the test suite](https://github.com/byjg/php-anydataset-db/tree/master/tests)
+3. Open an issue on [GitHub](https://github.com/byjg/php-anydataset-db/issues)
+
+---
+
+## Timeline
+
+| Version | Status | Notes |
+|---------|--------|-------|
+| 5.x | Maintenance | Security fixes only |
+| 6.0 | Current | Deprecated methods still work with warnings |
+| 6.x | Active Development | Full backward compatibility for deprecated features |
+| 7.0 | Future | Deprecated methods will be removed |
+
+**Recommendation:** Complete migration to the new API during the 6.x release cycle to ensure smooth transition to 7.0.

--- a/CHANGELOG-6.1.md
+++ b/CHANGELOG-6.1.md
@@ -1,0 +1,61 @@
+# Changelog - Version 6.1
+
+## Overview
+
+Version 6.1 is a backward-compatible feature release on top of 6.0. It introduces a generic
+observer mechanism for the `DatabaseExecutor` and, built on top of it, a Journal that records
+INSERT/UPDATE/DELETE operations with old and new values — designed for restoring database state
+between functional tests.
+
+No breaking changes: existing code runs unchanged, and the new event hooks add no measurable
+overhead when no observer is attached.
+
+---
+
+## New Features
+
+### 1. Executor Observers
+Generic event mechanism to observe queries and commands executed through the `DatabaseExecutor`:
+- New `DatabaseEventObserverInterface` attachable with `DatabaseExecutor::addObserver()` / removable with `removeObserver()`
+- Events: `BEFORE_QUERY`, `AFTER_QUERY`, `BEFORE_EXECUTE`, `AFTER_EXECUTE` (`DatabaseEventTypeEnum`)
+- Each notification carries a `DatabaseEvent` with the `SqlStatement` (SQL and parameters), the executor and the result
+- Enables decoupled auditing, metrics and query logging
+- Queries answered from the cache do not fire query events
+
+**Documentation:** [Executor Observers](docs/observers.md)
+
+### 2. Journal (Record and Restore Changes)
+Records all INSERT, UPDATE and DELETE statements with the row values before and after each operation:
+- `JournalRecorder` watches all tables or a specific set (`forAllTables()` / `forTables()`)
+- Configurable primary keys: `withPrimaryKey($table, $column)` and `withDefaultPrimaryKey($column)` (default `id`)
+- `JournalRestorer` replays the journal in reverse, restoring the previous database state
+- Optional strict mode (`->strict()`) throws a `JournalException` on statements that cannot be journaled/restored, instead of skipping them silently
+- Designed for functional tests (record on setUp, restore on tearDown)
+
+**Documentation:** [Journal](docs/journal.md)
+
+---
+
+## Known Limitations
+
+- The Journal recognizes only single-table DML statements; multi-statement SQL,
+  `INSERT ... SELECT`, multi-table UPDATEs and CTEs are not journaled
+  (strict mode fails loudly on them instead).
+- Observers are bound to an executor instance: the deprecated driver methods
+  (`$driver->execute()`, etc.) create a fresh internal executor per call and
+  therefore bypass observers. Migrate to the `DatabaseExecutor` API
+  (the deprecated methods are removed in 7.0).
+
+---
+
+## Upgrade Path from 6.0 to 6.1
+
+No code changes required. Update the composer constraint if you want to rely on the new API:
+
+```json
+{
+  "require": {
+    "byjg/anydataset-db": "^6.1"
+  }
+}
+```

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ $conn = \ByJG\AnyDataset\Db\Factory::getDbInstance("mysql://root:password@10.0.1
 
 - [Database Driver Interface](docs/db-driver-interface.md)
 - [DatabaseExecutor - Recommended API](docs/database-executor.md)
+- [Executor Observers](docs/observers.md)
+- [Journal (Record and Restore Changes)](docs/journal.md)
 - [Passing Parameters to PDODriver](docs/parameters.md)
 - [Generic PDO Driver](docs/generic-pdo-driver.md)
 - [Running Tests](docs/tests.md)

--- a/docs/deprecated-features.md
+++ b/docs/deprecated-features.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 18
+sidebar_position: 20
 ---
 
 # Deprecated Features

--- a/docs/generic-pdo-driver.md
+++ b/docs/generic-pdo-driver.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 15
 ---
 
 # Generic PDO Configuration

--- a/docs/journal.md
+++ b/docs/journal.md
@@ -1,0 +1,178 @@
+---
+sidebar_position: 13
+---
+
+# Journal (Record and Restore Changes)
+
+The Journal records all `INSERT`, `UPDATE` and `DELETE` statements executed through a
+`DatabaseExecutor`, capturing the row values **before** and **after** each operation.
+It can watch **all tables** or only a **specific set of tables**.
+
+Its main use case is functional testing: record everything the test changed and restore
+the previous state on tearDown — without recreating the database.
+
+It is built on top of the [Executor Observers](observers.md), so it is fully decoupled:
+if you don't attach it, nothing changes in your application.
+
+## Recording
+
+```php
+<?php
+use ByJG\AnyDataset\Db\DatabaseExecutor;
+use ByJG\AnyDataset\Db\Factory;
+use ByJG\AnyDataset\Db\Journal\JournalRecorder;
+
+$executor = DatabaseExecutor::using(Factory::getDbInstance('mysql://user:password@host/database'));
+
+// Watch all tables...
+$recorder = JournalRecorder::forAllTables();
+
+// ...or only specific tables
+$recorder = JournalRecorder::forTables('users', 'orders');
+
+$executor->addObserver($recorder);
+
+$executor->execute("insert into users (name) values (:name)", ['name' => 'John']);
+$executor->execute("update users set name = :name where id = :id", ['name' => 'Johnny', 'id' => 10]);
+$executor->execute("delete from users where id = :id", ['id' => 11]);
+
+foreach ($recorder->getEntries() as $entry) {
+    echo $entry->getOperation()->value;  // insert, update or delete
+    echo $entry->getTable();             // users
+    print_r($entry->getOldRows());       // rows BEFORE the operation (empty for insert)
+    print_r($entry->getNewRows());       // rows AFTER the operation (empty for delete)
+    echo $entry->getSql();               // the original SQL statement
+}
+```
+
+## Restoring (Setup and TearDown)
+
+The `JournalRestorer` replays the journal in reverse order:
+recorded INSERTs are deleted, UPDATEs have their old values written back,
+and DELETEs are re-inserted.
+
+```php
+<?php
+use ByJG\AnyDataset\Db\Journal\JournalRecorder;
+use ByJG\AnyDataset\Db\Journal\JournalRestorer;
+use PHPUnit\Framework\TestCase;
+
+class MyFunctionalTest extends TestCase
+{
+    protected DatabaseExecutor $executor;
+    protected JournalRecorder $recorder;
+
+    public function setUp(): void
+    {
+        $this->executor = DatabaseExecutor::using(Factory::getDbInstance('...'));
+
+        // strict() makes the test fail loudly if a statement cannot be
+        // journaled (and therefore could not be restored) - see Strict Mode below
+        $this->recorder = JournalRecorder::forAllTables()->strict();
+        $this->executor->addObserver($this->recorder);
+    }
+
+    public function tearDown(): void
+    {
+        $this->executor->removeObserver($this->recorder);
+        (new JournalRestorer())->restore($this->executor->getDriver(), $this->recorder);
+    }
+
+    public function testSomething()
+    {
+        // any insert/update/delete executed here (directly or by the code
+        // under test using this executor) will be reverted on tearDown
+    }
+}
+```
+
+The restore statements run through a dedicated executor without observers,
+so they are never recorded again.
+
+## Primary Keys
+
+The journal uses the primary key to capture rows after an `UPDATE` and to delete
+inserted rows on restore. By default it assumes the column `id`. You can configure it:
+
+```php
+<?php
+$recorder = JournalRecorder::forTables('products', 'users')
+    ->withPrimaryKey('products', 'sku')     // per table
+    ->withDefaultPrimaryKey('id');          // for all other tables
+```
+
+When an inserted table has no usable generated ID, the journal falls back to the values
+parsed from the INSERT statement, and the restore deletes the row by matching all
+captured values.
+
+## Strict Mode
+
+By default the recorder is *best-effort*: a write statement it cannot parse is executed
+normally but **not journaled** — which means it will **not be restored**. For the
+setUp/tearDown use case this silent gap can leak state to the next test.
+
+Strict mode turns those silent gaps into loud failures:
+
+```php
+<?php
+$recorder = JournalRecorder::forAllTables()->strict();
+$executor->addObserver($recorder);
+
+$executor->execute("INSERT INTO archive SELECT * FROM users");
+// => JournalException: cannot journal statement (unsupported DML shape).
+//    The statement was NOT executed.
+```
+
+In strict mode the recorder throws a `JournalException` when:
+
+- a **write statement cannot be parsed** (`INSERT ... SELECT`, multi-table UPDATE,
+  multi-statement SQL, `REPLACE`, `MERGE`, `TRUNCATE`). Thrown **before** the statement
+  executes, so the database is not modified. Because the target table cannot be
+  determined, this applies even when watching only specific tables;
+- the rows affected by an `UPDATE`/`DELETE` **cannot be captured** (also thrown before
+  execution);
+- the values of an `INSERT` **cannot be determined** (no generated ID and no parseable
+  values). This one is thrown **after** execution — the row was inserted — but the test
+  fails at the exact statement instead of leaking state silently.
+
+Non-write statements (SELECT, `CREATE TABLE`, `DROP`, `ALTER`, etc.) are never affected,
+so fixtures can still be built while recording.
+
+Use strict mode whenever the journal is your restore mechanism; use the default lenient
+mode when the journal is informational (audit/debugging).
+
+## How Old/New Values are Captured
+
+- `UPDATE`: the affected rows are selected (`SELECT * ... WHERE <same where clause>`)
+  before the operation; after the operation the rows are re-selected by primary key,
+  so the capture works even if the UPDATE changes columns referenced in the WHERE clause.
+- `DELETE`: the affected rows are selected before the operation.
+- `INSERT`: after the operation the row is selected by the generated ID
+  (falling back to the values parsed from the statement).
+
+All the extra SELECTs run on the same connection, so they see the data inside
+the current transaction, if any.
+
+## Limitations
+
+- Only **single-table DML** statements are recognized: `INSERT INTO ... VALUES (...)`,
+  `UPDATE ... SET ... [WHERE ...]` and `DELETE FROM ... [WHERE ...]`.
+  Multi-statement SQL, `INSERT ... SELECT`, multi-table UPDATEs and CTEs are **not** journaled
+  (enable [strict mode](#strict-mode) to fail loudly instead of skipping them).
+- Statements executed outside the observed `DatabaseExecutor` (another connection,
+  stored procedures, triggers) are not seen by the journal.
+- The deprecated driver methods (`$driver->execute()`, `$driver->getIterator()`, etc.)
+  bypass observers: each call internally creates a **fresh** `DatabaseExecutor`, so a
+  journal attached to your executor will not see those writes. Migrate the code under
+  test to the [DatabaseExecutor](database-executor.md) API (the deprecated methods are
+  removed in 7.0).
+- If the test code rolls back its own transaction, the journal still holds the entries of the
+  rolled-back statements; restoring them may re-apply unwanted changes. Clear the recorder
+  (`$recorder->clear()`) after a rollback.
+- Capturing values requires extra SELECT statements around each write; do not attach
+  the recorder in performance-sensitive production paths.
+
+## See Also
+
+- [Executor Observers](observers.md)
+- [DatabaseExecutor](database-executor.md)1

--- a/docs/literal-pdo-driver.md
+++ b/docs/literal-pdo-driver.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 23
+sidebar_position: 25
 ---
 
 # Literal PDO configuration

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 17
+sidebar_position: 19
 ---
 
 # Logging

--- a/docs/mysql.md
+++ b/docs/mysql.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 19
+sidebar_position: 21
 ---
 
 # Driver: MySQL

--- a/docs/observers.md
+++ b/docs/observers.md
@@ -1,0 +1,97 @@
+---
+sidebar_position: 12
+---
+
+# Executor Observers
+
+Starting from version 6.0, you can attach observers to a `DatabaseExecutor` to be notified about
+queries and commands executed against the database. This is the extension point used by features
+such as the [Journal](journal.md), and can also be used for auditing, metrics or custom query logging.
+
+## Events
+
+The events are defined by the `DatabaseEventTypeEnum`:
+
+| Event            | Fired                                                                  |
+|------------------|------------------------------------------------------------------------|
+| `BEFORE_QUERY`   | Before a query (`getIterator`/`getScalar`) is executed on the database |
+| `AFTER_QUERY`    | After a query was executed on the database                             |
+| `BEFORE_EXECUTE` | Before a command (`execute`/`executeAndGetId`) is executed             |
+| `AFTER_EXECUTE`  | After a command was executed                                           |
+
+Notes:
+
+- Queries answered from the [cache](cache.md) do **not** fire query events (no database round-trip happens).
+- `executeAndGetId()` fires the `EXECUTE` events for the INSERT statement and the `QUERY` events
+  for the statement retrieving the generated ID.
+- Observers are attached to a **specific executor instance**. The deprecated driver methods
+  (`$driver->execute()`, `$driver->getIterator()`, etc.) create a fresh `DatabaseExecutor`
+  internally on every call, so they bypass your observers. Use the
+  [DatabaseExecutor](database-executor.md) API (the deprecated methods are removed in 7.0).
+
+## Creating an Observer
+
+Implement the `DatabaseEventObserverInterface`:
+
+```php
+<?php
+use ByJG\AnyDataset\Db\DatabaseEvent;
+use ByJG\AnyDataset\Db\DatabaseEventTypeEnum;
+use ByJG\AnyDataset\Db\Interfaces\DatabaseEventObserverInterface;
+
+class QueryTimer implements DatabaseEventObserverInterface
+{
+    private array $start = [];
+    public array $timings = [];
+
+    public function subscribedEvents(): array
+    {
+        return [DatabaseEventTypeEnum::BEFORE_QUERY, DatabaseEventTypeEnum::AFTER_QUERY];
+    }
+
+    public function handleEvent(DatabaseEvent $event): void
+    {
+        if ($event->getType() === DatabaseEventTypeEnum::BEFORE_QUERY) {
+            $this->start[] = microtime(true);
+            return;
+        }
+
+        $this->timings[] = [
+            'sql' => $event->getStatement()->getSql(),
+            'elapsed' => microtime(true) - array_pop($this->start),
+        ];
+    }
+}
+```
+
+## Attaching and Detaching
+
+```php
+<?php
+use ByJG\AnyDataset\Db\DatabaseExecutor;
+use ByJG\AnyDataset\Db\Factory;
+
+$executor = DatabaseExecutor::using(Factory::getDbInstance('mysql://user:password@host/database'));
+
+$timer = new QueryTimer();
+$executor->addObserver($timer);
+
+$executor->getIterator('SELECT * FROM users');
+
+$executor->removeObserver($timer);
+```
+
+## The DatabaseEvent Object
+
+Each notification receives a `DatabaseEvent` with:
+
+- `getType()`: the `DatabaseEventTypeEnum` fired;
+- `getStatement()`: the `SqlStatement` (SQL text and parameters);
+- `getExecutor()`: the executor that fired the event — observers can use it to run additional
+  queries on the same connection (and same transaction);
+- `getResult()`: the operation result for `AFTER_*` events (`true` for `execute()`).
+
+## See Also
+
+- [Journal](journal.md) - record INSERT/UPDATE/DELETE with old and new values
+- [DatabaseExecutor](database-executor.md)

--- a/docs/oracle.md
+++ b/docs/oracle.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 21
+sidebar_position: 23
 ---
 
 # Driver: Oracle

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 14
 ---
 
 # Passing Parameters to PDODriver

--- a/docs/pdostatement.md
+++ b/docs/pdostatement.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 15
+sidebar_position: 17
 ---
 
 # Using a PDO Statement

--- a/docs/postgresql.md
+++ b/docs/postgresql.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 20
+sidebar_position: 22
 ---
 
 # Driver: PostgreSQL

--- a/docs/prefetch.md
+++ b/docs/prefetch.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 16
+sidebar_position: 18
 ---
 
 # Pre-Fetch Records

--- a/docs/sqlserver.md
+++ b/docs/sqlserver.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 22
+sidebar_position: 24
 ---
 
 # Driver: Microsoft SQL Server

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 14
+sidebar_position: 16
 ---
 
 # Running Unit tests

--- a/src/DatabaseEvent.php
+++ b/src/DatabaseEvent.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace ByJG\AnyDataset\Db;
+
+/**
+ * Immutable value object describing an event fired by the DatabaseExecutor.
+ */
+class DatabaseEvent
+{
+    public function __construct(
+        protected DatabaseEventTypeEnum $type,
+        protected DatabaseExecutor $executor,
+        protected SqlStatement $statement,
+        protected mixed $result = null
+    ) {
+    }
+
+    public function getType(): DatabaseEventTypeEnum
+    {
+        return $this->type;
+    }
+
+    /**
+     * The executor that fired the event. Observers can use it to run
+     * additional queries (the driver connection - and transaction - is shared).
+     */
+    public function getExecutor(): DatabaseExecutor
+    {
+        return $this->executor;
+    }
+
+    public function getStatement(): SqlStatement
+    {
+        return $this->statement;
+    }
+
+    /**
+     * The result of the operation (only for AFTER_* events).
+     * For AFTER_EXECUTE it is `true` (execute) or the operation result when available.
+     */
+    public function getResult(): mixed
+    {
+        return $this->result;
+    }
+}

--- a/src/DatabaseEventTypeEnum.php
+++ b/src/DatabaseEventTypeEnum.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace ByJG\AnyDataset\Db;
+
+/**
+ * Events fired by the DatabaseExecutor that can be observed
+ * through the DatabaseEventObserverInterface.
+ */
+enum DatabaseEventTypeEnum
+{
+    /** Fired before a query (getIterator/getScalar) is executed against the database. Cache hits do not fire this event. */
+    case BEFORE_QUERY;
+
+    /** Fired after a query (getIterator/getScalar) was executed against the database. Cache hits do not fire this event. */
+    case AFTER_QUERY;
+
+    /** Fired before a command (execute/executeAndGetId) is executed against the database. */
+    case BEFORE_EXECUTE;
+
+    /** Fired after a command (execute/executeAndGetId) was executed against the database. */
+    case AFTER_EXECUTE;
+}

--- a/src/DatabaseExecutor.php
+++ b/src/DatabaseExecutor.php
@@ -6,6 +6,7 @@ use ByJG\AnyDataset\Core\AnyDataset;
 use ByJG\AnyDataset\Core\Exception\DatabaseException;
 use ByJG\AnyDataset\Core\GenericIterator;
 use ByJG\AnyDataset\Db\Exception\DbDriverNotConnected;
+use ByJG\AnyDataset\Db\Interfaces\DatabaseEventObserverInterface;
 use ByJG\AnyDataset\Db\Interfaces\DbDriverInterface;
 use ByJG\AnyDataset\Db\Interfaces\DbTransactionInterface;
 use ByJG\AnyDataset\Db\Interfaces\SqlDialectInterface;
@@ -25,6 +26,11 @@ use Psr\SimpleCache\InvalidArgumentException as PsrInvalidArgumentException;
 class DatabaseExecutor implements DbTransactionInterface
 {
     protected DbDriverInterface $driver;
+
+    /**
+     * @var DatabaseEventObserverInterface[]
+     */
+    protected array $observers = [];
 
     /**
      * @param DbDriverInterface $driver The database driver to use for low-level operations
@@ -64,6 +70,52 @@ class DatabaseExecutor implements DbTransactionInterface
     }
 
     /**
+     * Attach an observer to be notified about queries and commands
+     * executed through this executor.
+     *
+     * @param DatabaseEventObserverInterface $observer
+     * @return static
+     */
+    public function addObserver(DatabaseEventObserverInterface $observer): static
+    {
+        if (!in_array($observer, $this->observers, true)) {
+            $this->observers[] = $observer;
+        }
+        return $this;
+    }
+
+    /**
+     * Detach a previously attached observer.
+     *
+     * @param DatabaseEventObserverInterface $observer
+     * @return static
+     */
+    public function removeObserver(DatabaseEventObserverInterface $observer): static
+    {
+        $this->observers = array_values(
+            array_filter($this->observers, fn($item) => $item !== $observer)
+        );
+        return $this;
+    }
+
+    /**
+     * Notify the attached observers subscribed to the given event type.
+     *
+     * @param DatabaseEventTypeEnum $type
+     * @param SqlStatement $statement
+     * @param mixed $result
+     * @return void
+     */
+    protected function notifyObservers(DatabaseEventTypeEnum $type, SqlStatement $statement, mixed $result = null): void
+    {
+        foreach ($this->observers as $observer) {
+            if (in_array($type, $observer->subscribedEvents(), true)) {
+                $observer->handleEvent(new DatabaseEvent($type, $this, $statement, $result));
+            }
+        }
+    }
+
+    /**
      * Execute a SQL statement and return an iterator over the results
      *
      * @param string|SqlStatement $sql The SQL statement to execute
@@ -94,8 +146,10 @@ class DatabaseExecutor implements DbTransactionInterface
 
         // If no cache is configured, directly execute the query
         if (empty($cache)) {
+            $this->notifyObservers(DatabaseEventTypeEnum::BEFORE_QUERY, $sql);
             $statement = $this->driver->prepareStatement($sqlText, $params);
             $this->driver->executeCursor($statement);
+            $this->notifyObservers(DatabaseEventTypeEnum::AFTER_QUERY, $sql);
             return $this->driver->getDriverIterator($statement, $preFetch, $sql->getEntityClass(), $sql->getEntityTransformer());
         }
 
@@ -126,8 +180,10 @@ class DatabaseExecutor implements DbTransactionInterface
 
         try {
             // Execute the query
+            $this->notifyObservers(DatabaseEventTypeEnum::BEFORE_QUERY, $sql);
             $statement = $this->driver->prepareStatement($sqlText, $params);
             $this->driver->executeCursor($statement);
+            $this->notifyObservers(DatabaseEventTypeEnum::AFTER_QUERY, $sql);
             $iterator = $this->driver->getDriverIterator($statement, preFetch: $preFetch, entityClass: $sql->getEntityClass(), entityTransformer: $sql->getEntityTransformer());
 
             // Cache the results
@@ -258,9 +314,11 @@ class DatabaseExecutor implements DbTransactionInterface
             $sql = $sql->withParams($array);
         }
 
+        $this->notifyObservers(DatabaseEventTypeEnum::BEFORE_EXECUTE, $sql);
         $statement = $this->driver->prepareStatement($sql->getSql(), $sql->getParams());
         $this->driver->executeCursor($statement);
         $this->driver->processMultiRowset($statement);
+        $this->notifyObservers(DatabaseEventTypeEnum::AFTER_EXECUTE, $sql, true);
 
         return true;
     }

--- a/src/Exception/JournalException.php
+++ b/src/Exception/JournalException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace ByJG\AnyDataset\Db\Exception;
+
+use RuntimeException;
+
+class JournalException extends RuntimeException
+{
+}

--- a/src/Exception/JournalRestoreException.php
+++ b/src/Exception/JournalRestoreException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace ByJG\AnyDataset\Db\Exception;
+
+class JournalRestoreException extends JournalException
+{
+}

--- a/src/Interfaces/DatabaseEventObserverInterface.php
+++ b/src/Interfaces/DatabaseEventObserverInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace ByJG\AnyDataset\Db\Interfaces;
+
+use ByJG\AnyDataset\Db\DatabaseEvent;
+use ByJG\AnyDataset\Db\DatabaseEventTypeEnum;
+
+/**
+ * Observer that can be attached to a DatabaseExecutor to be notified
+ * about queries and commands executed against the database.
+ *
+ * Implement this interface to add behaviors such as journaling, auditing,
+ * metrics or query logging without coupling them to the executor.
+ */
+interface DatabaseEventObserverInterface
+{
+    /**
+     * The list of events this observer wants to receive.
+     *
+     * @return DatabaseEventTypeEnum[]
+     */
+    public function subscribedEvents(): array;
+
+    /**
+     * Handle a subscribed event.
+     *
+     * @param DatabaseEvent $event
+     * @return void
+     */
+    public function handleEvent(DatabaseEvent $event): void;
+}

--- a/src/Journal/DmlParser.php
+++ b/src/Journal/DmlParser.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace ByJG\AnyDataset\Db\Journal;
+
+/**
+ * Lightweight parser to identify single-table DML statements
+ * (INSERT INTO ... VALUES, UPDATE ... SET, DELETE FROM).
+ *
+ * It intentionally does NOT parse complex statements (multi-statement SQL,
+ * INSERT ... SELECT, multi-table UPDATE, CTEs, etc.) - for those it returns null
+ * and the statement will not be journaled.
+ */
+class DmlParser
+{
+    protected const TABLE_PATTERN = '(?<table>[`"\[\]\w.]+)';
+
+    /**
+     * Parse a SQL statement and return the DML metadata or null when
+     * the statement is not a supported single-table DML.
+     *
+     * @param string $sql
+     * @return ParsedDml|null
+     */
+    public static function parse(string $sql): ?ParsedDml
+    {
+        $sql = trim(rtrim(trim($sql), ';'));
+
+        // Multi-statement SQL is not supported
+        if (str_contains($sql, ';')) {
+            return null;
+        }
+
+        return self::parseInsert($sql)
+            ?? self::parseUpdate($sql)
+            ?? self::parseDelete($sql);
+    }
+
+    protected static function parseInsert(string $sql): ?ParsedDml
+    {
+        $pattern = '~^insert\s+into\s+' . self::TABLE_PATTERN . '\s*\((?<columns>[^)]+)\)\s*values\s*\((?<values>.+)\)\s*$~is';
+        if (!preg_match($pattern, $sql, $matches)) {
+            return null;
+        }
+
+        $columns = array_map(
+            fn($column) => self::stripDelimiters($column),
+            explode(',', $matches['columns'])
+        );
+        $values = self::splitTopLevel($matches['values']);
+
+        $insertValues = [];
+        if (count($columns) === count($values)) {
+            $insertValues = array_combine($columns, array_map('trim', $values));
+        }
+
+        return new ParsedDml(
+            JournalOperationEnum::INSERT,
+            self::stripDelimiters($matches['table']),
+            null,
+            $insertValues
+        );
+    }
+
+    protected static function parseUpdate(string $sql): ?ParsedDml
+    {
+        $pattern = '~^update\s+' . self::TABLE_PATTERN . '\s+set\s+.+?(?:\s+where\s+(?<where>.+))?$~is';
+        if (!preg_match($pattern, $sql, $matches)) {
+            return null;
+        }
+
+        return new ParsedDml(
+            JournalOperationEnum::UPDATE,
+            self::stripDelimiters($matches['table']),
+            empty($matches['where']) ? null : trim($matches['where'])
+        );
+    }
+
+    protected static function parseDelete(string $sql): ?ParsedDml
+    {
+        $pattern = '~^delete\s+from\s+' . self::TABLE_PATTERN . '(?:\s+where\s+(?<where>.+))?$~is';
+        if (!preg_match($pattern, $sql, $matches)) {
+            return null;
+        }
+
+        return new ParsedDml(
+            JournalOperationEnum::DELETE,
+            self::stripDelimiters($matches['table']),
+            empty($matches['where']) ? null : trim($matches['where'])
+        );
+    }
+
+    /**
+     * Remove identifier delimiters (backticks, double quotes, square brackets) and trim.
+     */
+    public static function stripDelimiters(string $identifier): string
+    {
+        return trim(str_replace(['`', '"', '[', ']'], '', $identifier));
+    }
+
+    /**
+     * Split a comma-separated expression list, ignoring commas inside
+     * parentheses and single-quoted strings.
+     *
+     * @param string $expression
+     * @return string[]
+     */
+    protected static function splitTopLevel(string $expression): array
+    {
+        $result = [];
+        $current = '';
+        $depth = 0;
+        $inString = false;
+        $length = strlen($expression);
+
+        for ($i = 0; $i < $length; $i++) {
+            $char = $expression[$i];
+
+            if ($inString) {
+                $current .= $char;
+                if ($char === "'") {
+                    // Handle escaped quote ('')
+                    if ($i + 1 < $length && $expression[$i + 1] === "'") {
+                        $current .= $expression[++$i];
+                    } else {
+                        $inString = false;
+                    }
+                }
+                continue;
+            }
+
+            switch ($char) {
+                case "'":
+                    $inString = true;
+                    $current .= $char;
+                    break;
+                case '(':
+                    $depth++;
+                    $current .= $char;
+                    break;
+                case ')':
+                    $depth--;
+                    $current .= $char;
+                    break;
+                case ',':
+                    if ($depth === 0) {
+                        $result[] = $current;
+                        $current = '';
+                    } else {
+                        $current .= $char;
+                    }
+                    break;
+                default:
+                    $current .= $char;
+            }
+        }
+
+        if (trim($current) !== '') {
+            $result[] = $current;
+        }
+
+        return $result;
+    }
+}

--- a/src/Journal/JournalEntry.php
+++ b/src/Journal/JournalEntry.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace ByJG\AnyDataset\Db\Journal;
+
+/**
+ * A single recorded DML operation with the row values
+ * before (oldRows) and after (newRows) the operation.
+ */
+class JournalEntry
+{
+    /**
+     * @param JournalOperationEnum $operation
+     * @param string $table
+     * @param array<int, array<string, mixed>> $oldRows Rows as they were BEFORE the operation (empty for INSERT)
+     * @param array<int, array<string, mixed>> $newRows Rows as they are AFTER the operation (empty for DELETE)
+     * @param string $sql The original SQL statement
+     * @param array $params The original parameters
+     */
+    public function __construct(
+        protected JournalOperationEnum $operation,
+        protected string $table,
+        protected array $oldRows,
+        protected array $newRows,
+        protected string $sql,
+        protected array $params
+    ) {
+    }
+
+    public function getOperation(): JournalOperationEnum
+    {
+        return $this->operation;
+    }
+
+    public function getTable(): string
+    {
+        return $this->table;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getOldRows(): array
+    {
+        return $this->oldRows;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getNewRows(): array
+    {
+        return $this->newRows;
+    }
+
+    public function getSql(): string
+    {
+        return $this->sql;
+    }
+
+    public function getParams(): array
+    {
+        return $this->params;
+    }
+}

--- a/src/Journal/JournalOperationEnum.php
+++ b/src/Journal/JournalOperationEnum.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace ByJG\AnyDataset\Db\Journal;
+
+enum JournalOperationEnum: string
+{
+    case INSERT = 'insert';
+    case UPDATE = 'update';
+    case DELETE = 'delete';
+}

--- a/src/Journal/JournalRecorder.php
+++ b/src/Journal/JournalRecorder.php
@@ -1,0 +1,415 @@
+<?php
+
+namespace ByJG\AnyDataset\Db\Journal;
+
+use ByJG\AnyDataset\Db\DatabaseEvent;
+use ByJG\AnyDataset\Db\DatabaseEventTypeEnum;
+use ByJG\AnyDataset\Db\Exception\JournalException;
+use ByJG\AnyDataset\Db\Interfaces\DatabaseEventObserverInterface;
+use Throwable;
+
+/**
+ * Observer that records all INSERT, UPDATE and DELETE statements executed
+ * through a DatabaseExecutor, capturing the row values before and after
+ * each operation.
+ *
+ * Attach it to an executor with `$executor->addObserver($recorder)`.
+ * It can watch ALL tables (default) or a specific set of tables.
+ *
+ * The journal can later be replayed in reverse by the JournalRestorer
+ * to return the database to the state before the recording started
+ * (e.g. PHPUnit setUp/tearDown).
+ *
+ * Limitations: only single-table DML statements are recognized
+ * (INSERT INTO ... VALUES, UPDATE ... SET ... WHERE, DELETE FROM ... WHERE).
+ * Multi-statement SQL, INSERT...SELECT and multi-table UPDATEs are ignored.
+ */
+class JournalRecorder implements DatabaseEventObserverInterface
+{
+    /** @var JournalEntry[] */
+    protected array $entries = [];
+
+    /** @var string[]|null Lowercased table names to watch; null = all tables */
+    protected ?array $tables = null;
+
+    /** @var array<string, string> Map of lowercased table name => primary key column */
+    protected array $primaryKeys = [];
+
+    protected string $defaultPrimaryKey = 'id';
+
+    protected bool $strict = false;
+
+    /**
+     * Stack of pending operations captured on BEFORE_EXECUTE and
+     * consumed on AFTER_EXECUTE.
+     *
+     * @var array<int, array{dml: ParsedDml, oldRows: array<int, array<string, mixed>>}|null>
+     */
+    protected array $pending = [];
+
+    /**
+     * @param string[]|null $tables Tables to watch; null watches all tables
+     */
+    public function __construct(?array $tables = null)
+    {
+        $this->tables = is_null($tables) ? null : array_map('strtolower', $tables);
+    }
+
+    /**
+     * Create a recorder watching all tables.
+     */
+    public static function forAllTables(): static
+    {
+        return new static();
+    }
+
+    /**
+     * Create a recorder watching only the given tables.
+     */
+    public static function forTables(string ...$tables): static
+    {
+        return new static($tables);
+    }
+
+    /**
+     * Define the primary key column of a table (default is "id").
+     * The primary key is used to capture the rows after an UPDATE and
+     * to delete inserted rows on restore.
+     */
+    public function withPrimaryKey(string $table, string $column): static
+    {
+        $this->primaryKeys[strtolower($table)] = $column;
+        return $this;
+    }
+
+    /**
+     * Change the primary key column assumed for tables without
+     * an explicit definition (default is "id").
+     */
+    public function withDefaultPrimaryKey(string $column): static
+    {
+        $this->defaultPrimaryKey = $column;
+        return $this;
+    }
+
+    /**
+     * Enable strict mode: instead of silently skipping, the recorder throws
+     * a JournalException when it cannot guarantee the operation can be restored:
+     *
+     * - a write statement (INSERT/UPDATE/DELETE/REPLACE/MERGE/TRUNCATE) cannot be
+     *   parsed (thrown BEFORE the statement executes, so the database is not modified);
+     * - the rows affected by an UPDATE/DELETE cannot be captured (also thrown
+     *   before execution);
+     * - the values of an INSERT cannot be determined (thrown after execution).
+     *
+     * Non-write statements (SELECT, DDL such as CREATE/DROP/ALTER) are never affected.
+     *
+     * Recommended when the journal is used to restore state between tests, where
+     * a silently incomplete journal would leak state to the next test.
+     */
+    public function strict(bool $strict = true): static
+    {
+        $this->strict = $strict;
+        return $this;
+    }
+
+    public function isStrict(): bool
+    {
+        return $this->strict;
+    }
+
+    /**
+     * @return JournalEntry[]
+     */
+    public function getEntries(): array
+    {
+        return $this->entries;
+    }
+
+    public function count(): int
+    {
+        return count($this->entries);
+    }
+
+    public function clear(): void
+    {
+        $this->entries = [];
+        $this->pending = [];
+    }
+
+    public function primaryKeyFor(string $table): string
+    {
+        return $this->primaryKeys[strtolower($table)] ?? $this->defaultPrimaryKey;
+    }
+
+    #[\Override]
+    public function subscribedEvents(): array
+    {
+        return [DatabaseEventTypeEnum::BEFORE_EXECUTE, DatabaseEventTypeEnum::AFTER_EXECUTE];
+    }
+
+    #[\Override]
+    public function handleEvent(DatabaseEvent $event): void
+    {
+        if ($event->getType() === DatabaseEventTypeEnum::BEFORE_EXECUTE) {
+            $this->beforeExecute($event);
+        } elseif ($event->getType() === DatabaseEventTypeEnum::AFTER_EXECUTE) {
+            $this->afterExecute($event);
+        }
+    }
+
+    protected function isWatched(string $table): bool
+    {
+        return is_null($this->tables) || in_array(strtolower($table), $this->tables, true);
+    }
+
+    protected function beforeExecute(DatabaseEvent $event): void
+    {
+        $sql = $event->getStatement()->getSql();
+        $dml = DmlParser::parse($sql);
+
+        if (is_null($dml)) {
+            // In strict mode a write statement that cannot be journaled is rejected
+            // BEFORE it executes. The target table cannot be determined, so this
+            // applies even when watching only specific tables.
+            if ($this->strict && $this->looksLikeWrite($sql)) {
+                throw new JournalException(
+                    "Journal strict mode: cannot journal statement (unsupported DML shape). " .
+                    "The statement was NOT executed. SQL: $sql"
+                );
+            }
+            $this->pending[] = null;
+            return;
+        }
+
+        if (!$this->isWatched($dml->getTable())) {
+            $this->pending[] = null;
+            return;
+        }
+
+        $oldRows = [];
+        if ($dml->getOperation() !== JournalOperationEnum::INSERT) {
+            try {
+                $oldRows = $this->fetchRows(
+                    $event,
+                    $dml->getTable(),
+                    $dml->getWhere(),
+                    $event->getStatement()->getParams()
+                );
+            } catch (Throwable $ex) {
+                if ($this->strict) {
+                    throw new JournalException(
+                        "Journal strict mode: could not capture the rows affected by the statement, " .
+                        "so it would not be restorable. The statement was NOT executed. " .
+                        "SQL: $sql. Reason: " . $ex->getMessage(),
+                        0,
+                        $ex
+                    );
+                }
+                // Never let journaling break the main statement.
+                $event->getExecutor()->getDriver()->log(
+                    "Journal: could not capture old rows for '{$dml->getTable()}': " . $ex->getMessage()
+                );
+                $this->pending[] = null;
+                return;
+            }
+        }
+
+        $this->pending[] = ['dml' => $dml, 'oldRows' => $oldRows];
+    }
+
+    /**
+     * Whether the statement looks like a data modification statement.
+     */
+    protected function looksLikeWrite(string $sql): bool
+    {
+        return preg_match('~^\s*(insert|update|delete|replace|merge|truncate)\b~i', $sql) === 1;
+    }
+
+    protected function afterExecute(DatabaseEvent $event): void
+    {
+        $pending = array_pop($this->pending);
+        if (is_null($pending)) {
+            return;
+        }
+
+        $dml = $pending['dml'];
+        $oldRows = $pending['oldRows'];
+        $statement = $event->getStatement();
+
+        try {
+            $newRows = match ($dml->getOperation()) {
+                JournalOperationEnum::INSERT => $this->captureInsertedRows($event, $dml),
+                JournalOperationEnum::UPDATE => $this->captureUpdatedRows($event, $dml, $oldRows),
+                JournalOperationEnum::DELETE => [],
+            };
+        } catch (Throwable $ex) {
+            $event->getExecutor()->getDriver()->log(
+                "Journal: could not capture new rows for '{$dml->getTable()}': " . $ex->getMessage()
+            );
+            $newRows = [];
+        }
+
+        // Without the new values an INSERT cannot be reverted. An UPDATE/DELETE is
+        // still restorable from the old rows, so only the INSERT is fatal in strict mode.
+        if ($this->strict && $dml->getOperation() === JournalOperationEnum::INSERT && empty($newRows)) {
+            throw new JournalException(
+                "Journal strict mode: the inserted values could not be captured, so the INSERT " .
+                "cannot be reverted. NOTE: the statement WAS executed. SQL: {$statement->getSql()}"
+            );
+        }
+
+        $this->entries[] = new JournalEntry(
+            $dml->getOperation(),
+            $dml->getTable(),
+            $oldRows,
+            $newRows,
+            $statement->getSql(),
+            $statement->getParams() ?? []
+        );
+    }
+
+    /**
+     * Capture the row just inserted, preferring a SELECT by the generated id.
+     * Falls back to the values parsed from the INSERT statement.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected function captureInsertedRows(DatabaseEvent $event, ParsedDml $dml): array
+    {
+        $executor = $event->getExecutor();
+        $resolvedValues = $dml->resolveInsertValues($event->getStatement()->getParams());
+
+        try {
+            $primaryKey = $this->primaryKeyFor($dml->getTable());
+            $lastId = $executor->getScalar($executor->getHelper()->getSqlLastInsertId());
+
+            if (!empty($lastId)) {
+                $rows = $this->fetchRows(
+                    $event,
+                    $dml->getTable(),
+                    "$primaryKey = :journal_pk_value",
+                    ['journal_pk_value' => $lastId]
+                );
+
+                // The last-insert-id can be stale when the table has no auto increment
+                // column. Only trust the fetched row if it matches the statement values.
+                if (count($rows) === 1 && $this->rowMatches($rows[0], $resolvedValues)) {
+                    return $rows;
+                }
+            }
+        } catch (Throwable $ex) {
+            // e.g. PostgreSQL lastval() throws when no sequence was used in the session
+            $executor->getDriver()->log(
+                "Journal: could not fetch inserted row for '{$dml->getTable()}': " . $ex->getMessage()
+            );
+        }
+
+        return empty($resolvedValues) ? [] : [$resolvedValues];
+    }
+
+    /**
+     * Capture the rows after an UPDATE, selecting them by the primary key
+     * of the rows captured before the operation. When the primary key is not
+     * available, re-run the original WHERE clause as a best effort.
+     *
+     * @param array<int, array<string, mixed>> $oldRows
+     * @return array<int, array<string, mixed>>
+     */
+    protected function captureUpdatedRows(DatabaseEvent $event, ParsedDml $dml, array $oldRows): array
+    {
+        if (empty($oldRows)) {
+            return [];
+        }
+
+        $primaryKey = $this->primaryKeyFor($dml->getTable());
+        $pkColumn = $this->findKey($oldRows[0], $primaryKey);
+
+        if (is_null($pkColumn)) {
+            // Fallback: re-run the original WHERE clause. Note this can miss rows
+            // if the UPDATE changed a column referenced in the WHERE clause.
+            return $this->fetchRows(
+                $event,
+                $dml->getTable(),
+                $dml->getWhere(),
+                $event->getStatement()->getParams()
+            );
+        }
+
+        $newRows = [];
+        foreach ($oldRows as $oldRow) {
+            $rows = $this->fetchRows(
+                $event,
+                $dml->getTable(),
+                "$pkColumn = :journal_pk_value",
+                ['journal_pk_value' => $oldRow[$pkColumn]]
+            );
+            foreach ($rows as $row) {
+                $newRows[] = $row;
+            }
+        }
+
+        return $newRows;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    protected function fetchRows(DatabaseEvent $event, string $table, ?string $where, ?array $params): array
+    {
+        $sql = "SELECT * FROM $table" . (empty($where) ? "" : " WHERE $where");
+        $iterator = $event->getExecutor()->getIterator($sql, $params ?? []);
+
+        $rows = [];
+        foreach ($iterator as $row) {
+            $rows[] = $row->toArray();
+        }
+        return $rows;
+    }
+
+    /**
+     * Find a key in the row matching the given name (case-insensitive).
+     */
+    protected function findKey(array $row, string $name): ?string
+    {
+        foreach (array_keys($row) as $key) {
+            if (strcasecmp((string)$key, $name) === 0) {
+                return (string)$key;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Loosely compare a fetched row against the values resolved from
+     * the INSERT statement.
+     *
+     * @param array<string, mixed> $row
+     * @param array<string, mixed> $values
+     */
+    protected function rowMatches(array $row, array $values): bool
+    {
+        foreach ($values as $column => $value) {
+            $key = $this->findKey($row, $column);
+            if (is_null($key)) {
+                continue;
+            }
+            if (is_null($value) || is_null($row[$key])) {
+                if (!is_null($value) || !is_null($row[$key])) {
+                    return false;
+                }
+                continue;
+            }
+            if (is_numeric($row[$key]) && is_numeric($value)) {
+                if ((float)$row[$key] !== (float)$value) {
+                    return false;
+                }
+                continue;
+            }
+            if ((string)$row[$key] !== (string)$value) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/Journal/JournalRestorer.php
+++ b/src/Journal/JournalRestorer.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace ByJG\AnyDataset\Db\Journal;
+
+use ByJG\AnyDataset\Db\DatabaseExecutor;
+use ByJG\AnyDataset\Db\Exception\JournalRestoreException;
+use ByJG\AnyDataset\Db\Interfaces\DbDriverInterface;
+
+/**
+ * Replays a JournalRecorder in reverse order, returning the database to the
+ * state it had before the recording started:
+ *
+ * - recorded INSERTs are deleted;
+ * - recorded UPDATEs have their old values written back;
+ * - recorded DELETEs are re-inserted.
+ *
+ * Typical usage in a functional test:
+ *
+ * <code>
+ * // setUp
+ * $recorder = JournalRecorder::forAllTables();
+ * $executor->addObserver($recorder);
+ *
+ * // tearDown
+ * $executor->removeObserver($recorder);
+ * (new JournalRestorer())->restore($executor->getDriver(), $recorder);
+ * </code>
+ */
+class JournalRestorer
+{
+    /**
+     * Restore the database state by replaying the journal in reverse.
+     *
+     * The restore statements are executed through a dedicated executor
+     * (without observers), so they are not recorded again.
+     *
+     * @param DbDriverInterface $driver
+     * @param JournalRecorder $recorder
+     * @param bool $clear Clear the recorder after a successful restore (default true)
+     * @return void
+     */
+    public function restore(DbDriverInterface $driver, JournalRecorder $recorder, bool $clear = true): void
+    {
+        $executor = DatabaseExecutor::using($driver);
+
+        foreach (array_reverse($recorder->getEntries()) as $entry) {
+            match ($entry->getOperation()) {
+                JournalOperationEnum::INSERT => $this->revertInsert($executor, $recorder, $entry),
+                JournalOperationEnum::UPDATE => $this->revertUpdate($executor, $recorder, $entry),
+                JournalOperationEnum::DELETE => $this->revertDelete($executor, $entry),
+            };
+        }
+
+        if ($clear) {
+            $recorder->clear();
+        }
+    }
+
+    protected function revertInsert(DatabaseExecutor $executor, JournalRecorder $recorder, JournalEntry $entry): void
+    {
+        if (empty($entry->getNewRows())) {
+            throw new JournalRestoreException(
+                "Cannot revert INSERT on '{$entry->getTable()}': no new values were captured. SQL: {$entry->getSql()}"
+            );
+        }
+
+        $primaryKey = $recorder->primaryKeyFor($entry->getTable());
+
+        foreach ($entry->getNewRows() as $row) {
+            $pkColumn = $this->findKey($row, $primaryKey);
+            if (!is_null($pkColumn) && !is_null($row[$pkColumn])) {
+                $executor->execute(
+                    "DELETE FROM {$entry->getTable()} WHERE $pkColumn = :journal_pk_value",
+                    ['journal_pk_value' => $row[$pkColumn]]
+                );
+                continue;
+            }
+
+            // No primary key available: delete by matching all captured values
+            [$where, $params] = $this->buildMatchClause($row);
+            $executor->execute("DELETE FROM {$entry->getTable()} WHERE $where", $params);
+        }
+    }
+
+    protected function revertUpdate(DatabaseExecutor $executor, JournalRecorder $recorder, JournalEntry $entry): void
+    {
+        $primaryKey = $recorder->primaryKeyFor($entry->getTable());
+
+        foreach ($entry->getOldRows() as $row) {
+            $pkColumn = $this->findKey($row, $primaryKey);
+            if (is_null($pkColumn)) {
+                throw new JournalRestoreException(
+                    "Cannot revert UPDATE on '{$entry->getTable()}': primary key column '$primaryKey' " .
+                    "was not found in the captured rows. Configure it with JournalRecorder::withPrimaryKey()."
+                );
+            }
+
+            $set = [];
+            $params = ['journal_pk_value' => $row[$pkColumn]];
+            foreach ($row as $column => $value) {
+                if ($column === $pkColumn) {
+                    continue;
+                }
+                $paramName = 'journal_set_' . count($params);
+                $set[] = "$column = :$paramName";
+                $params[$paramName] = $value;
+            }
+
+            if (empty($set)) {
+                continue;
+            }
+
+            $executor->execute(
+                "UPDATE {$entry->getTable()} SET " . implode(', ', $set) .
+                " WHERE $pkColumn = :journal_pk_value",
+                $params
+            );
+        }
+    }
+
+    protected function revertDelete(DatabaseExecutor $executor, JournalEntry $entry): void
+    {
+        foreach ($entry->getOldRows() as $row) {
+            $columns = [];
+            $placeholders = [];
+            $params = [];
+            foreach ($row as $column => $value) {
+                $paramName = 'journal_val_' . count($params);
+                $columns[] = $column;
+                $placeholders[] = ":$paramName";
+                $params[$paramName] = $value;
+            }
+
+            $executor->execute(
+                "INSERT INTO {$entry->getTable()} (" . implode(', ', $columns) . ") " .
+                "VALUES (" . implode(', ', $placeholders) . ")",
+                $params
+            );
+        }
+    }
+
+    /**
+     * Build a WHERE clause matching all the row values (NULL-safe).
+     *
+     * @param array<string, mixed> $row
+     * @return array{0: string, 1: array<string, mixed>}
+     */
+    protected function buildMatchClause(array $row): array
+    {
+        $conditions = [];
+        $params = [];
+        foreach ($row as $column => $value) {
+            if (is_null($value)) {
+                $conditions[] = "$column IS NULL";
+                continue;
+            }
+            $paramName = 'journal_match_' . count($params);
+            $conditions[] = "$column = :$paramName";
+            $params[$paramName] = $value;
+        }
+
+        return [implode(' AND ', $conditions), $params];
+    }
+
+    /**
+     * Find a key in the row matching the given name (case-insensitive).
+     */
+    protected function findKey(array $row, string $name): ?string
+    {
+        foreach (array_keys($row) as $key) {
+            if (strcasecmp((string)$key, $name) === 0) {
+                return (string)$key;
+            }
+        }
+        return null;
+    }
+}

--- a/src/Journal/ParsedDml.php
+++ b/src/Journal/ParsedDml.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace ByJG\AnyDataset\Db\Journal;
+
+/**
+ * Result of parsing a DML (INSERT/UPDATE/DELETE) SQL statement.
+ */
+class ParsedDml
+{
+    /**
+     * @param JournalOperationEnum $operation
+     * @param string $table Table name without delimiters
+     * @param string|null $where The raw WHERE clause (without the WHERE keyword), if any
+     * @param array<string, string> $insertValues Map of column => raw value expression (INSERT only)
+     */
+    public function __construct(
+        protected JournalOperationEnum $operation,
+        protected string $table,
+        protected ?string $where = null,
+        protected array $insertValues = []
+    ) {
+    }
+
+    public function getOperation(): JournalOperationEnum
+    {
+        return $this->operation;
+    }
+
+    public function getTable(): string
+    {
+        return $this->table;
+    }
+
+    public function getWhere(): ?string
+    {
+        return $this->where;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getInsertValues(): array
+    {
+        return $this->insertValues;
+    }
+
+    /**
+     * Resolve the parsed INSERT value expressions against the statement parameters.
+     * Named parameters (:name) are replaced by their values; simple quoted/numeric
+     * literals are converted; other expressions (functions, etc.) are discarded.
+     *
+     * @param array|null $params
+     * @return array<string, mixed>
+     */
+    public function resolveInsertValues(?array $params): array
+    {
+        $result = [];
+        foreach ($this->insertValues as $column => $expression) {
+            $expression = trim($expression);
+            if (preg_match('~^:(?<param>[_\w\d]+)$~', $expression, $matches)) {
+                if (is_array($params) && array_key_exists($matches['param'], $params)) {
+                    $result[$column] = $params[$matches['param']];
+                }
+                continue;
+            }
+            if (is_numeric($expression)) {
+                $result[$column] = str_contains($expression, '.') ? (float)$expression : (int)$expression;
+                continue;
+            }
+            if (preg_match("~^'(?<value>[^']*)'$~", $expression, $matches)) {
+                $result[$column] = $matches['value'];
+                continue;
+            }
+            if (strcasecmp($expression, 'null') === 0) {
+                $result[$column] = null;
+            }
+            // Any other expression (functions, sub-selects, etc.) cannot be resolved statically
+        }
+        return $result;
+    }
+}

--- a/tests/DatabaseExecutorObserverTest.php
+++ b/tests/DatabaseExecutorObserverTest.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Test;
+
+use ByJG\AnyDataset\Db\DatabaseEvent;
+use ByJG\AnyDataset\Db\DatabaseEventTypeEnum;
+use ByJG\AnyDataset\Db\DatabaseExecutor;
+use ByJG\AnyDataset\Db\Factory;
+use ByJG\AnyDataset\Db\Interfaces\DatabaseEventObserverInterface;
+use ByJG\AnyDataset\Db\Interfaces\DbDriverInterface;
+use Override;
+use PHPUnit\Framework\TestCase;
+
+class ObserverSpy implements DatabaseEventObserverInterface
+{
+    /** @var DatabaseEvent[] */
+    public array $events = [];
+
+    /** @var DatabaseEventTypeEnum[] */
+    public array $subscribed;
+
+    public function __construct(?array $subscribed = null)
+    {
+        $this->subscribed = $subscribed ?? [
+            DatabaseEventTypeEnum::BEFORE_QUERY,
+            DatabaseEventTypeEnum::AFTER_QUERY,
+            DatabaseEventTypeEnum::BEFORE_EXECUTE,
+            DatabaseEventTypeEnum::AFTER_EXECUTE,
+        ];
+    }
+
+    #[Override]
+    public function subscribedEvents(): array
+    {
+        return $this->subscribed;
+    }
+
+    #[Override]
+    public function handleEvent(DatabaseEvent $event): void
+    {
+        $this->events[] = $event;
+    }
+
+    /**
+     * @return DatabaseEventTypeEnum[]
+     */
+    public function eventTypes(): array
+    {
+        return array_map(fn(DatabaseEvent $event) => $event->getType(), $this->events);
+    }
+}
+
+class DatabaseExecutorObserverTest extends TestCase
+{
+    protected DbDriverInterface $dbDriver;
+
+    protected DatabaseExecutor $executor;
+
+    protected string $dbFile = '/tmp/observer_test.db';
+
+    #[Override]
+    public function setUp(): void
+    {
+        $this->dbDriver = Factory::getDbInstance('sqlite://' . $this->dbFile);
+        $this->executor = DatabaseExecutor::using($this->dbDriver);
+
+        $this->executor->execute(
+            'create table users (
+            id integer primary key autoincrement,
+            name varchar(45));'
+        );
+    }
+
+    #[Override]
+    public function tearDown(): void
+    {
+        unset($this->executor);
+        unset($this->dbDriver);
+        if (file_exists($this->dbFile)) {
+            unlink($this->dbFile);
+        }
+    }
+
+    public function testExecuteFiresExecuteEvents()
+    {
+        $spy = new ObserverSpy();
+        $this->executor->addObserver($spy);
+
+        $this->executor->execute("insert into users (name) values (:name)", ['name' => 'John']);
+
+        $this->assertEquals(
+            [DatabaseEventTypeEnum::BEFORE_EXECUTE, DatabaseEventTypeEnum::AFTER_EXECUTE],
+            $spy->eventTypes()
+        );
+
+        $this->assertEquals("insert into users (name) values (:name)", $spy->events[0]->getStatement()->getSql());
+        $this->assertEquals(['name' => 'John'], $spy->events[0]->getStatement()->getParams());
+        $this->assertNull($spy->events[0]->getResult());
+        $this->assertTrue($spy->events[1]->getResult());
+        $this->assertSame($this->executor, $spy->events[0]->getExecutor());
+    }
+
+    public function testGetIteratorFiresQueryEvents()
+    {
+        $spy = new ObserverSpy();
+        $this->executor->addObserver($spy);
+
+        $this->executor->getIterator("select * from users where id = :id", ['id' => 1]);
+
+        $this->assertEquals(
+            [DatabaseEventTypeEnum::BEFORE_QUERY, DatabaseEventTypeEnum::AFTER_QUERY],
+            $spy->eventTypes()
+        );
+        $this->assertEquals("select * from users where id = :id", $spy->events[0]->getStatement()->getSql());
+        $this->assertEquals(['id' => 1], $spy->events[0]->getStatement()->getParams());
+    }
+
+    public function testExecuteAndGetIdFiresExecuteEvents()
+    {
+        $spy = new ObserverSpy();
+        $this->executor->addObserver($spy);
+
+        $id = $this->executor->executeAndGetId("insert into users (name) values (:name)", ['name' => 'Jane']);
+
+        $this->assertEquals(1, $id);
+        // The insert fires execute events; fetching the generated id fires query events.
+        $this->assertEquals(
+            [
+                DatabaseEventTypeEnum::BEFORE_EXECUTE,
+                DatabaseEventTypeEnum::AFTER_EXECUTE,
+                DatabaseEventTypeEnum::BEFORE_QUERY,
+                DatabaseEventTypeEnum::AFTER_QUERY,
+            ],
+            $spy->eventTypes()
+        );
+    }
+
+    public function testObserverReceivesOnlySubscribedEvents()
+    {
+        $spy = new ObserverSpy([DatabaseEventTypeEnum::AFTER_EXECUTE]);
+        $this->executor->addObserver($spy);
+
+        $this->executor->execute("insert into users (name) values ('John')");
+        $this->executor->getIterator("select * from users");
+
+        $this->assertEquals([DatabaseEventTypeEnum::AFTER_EXECUTE], $spy->eventTypes());
+    }
+
+    public function testRemoveObserverStopsNotifications()
+    {
+        $spy = new ObserverSpy();
+        $this->executor->addObserver($spy);
+
+        $this->executor->execute("insert into users (name) values ('John')");
+        $this->assertCount(2, $spy->events);
+
+        $this->executor->removeObserver($spy);
+        $this->executor->execute("insert into users (name) values ('Jane')");
+        $this->assertCount(2, $spy->events);
+    }
+
+    public function testAddSameObserverTwiceNotifiesOnce()
+    {
+        $spy = new ObserverSpy();
+        $this->executor->addObserver($spy);
+        $this->executor->addObserver($spy);
+
+        $this->executor->execute("insert into users (name) values ('John')");
+
+        $this->assertEquals(
+            [DatabaseEventTypeEnum::BEFORE_EXECUTE, DatabaseEventTypeEnum::AFTER_EXECUTE],
+            $spy->eventTypes()
+        );
+    }
+
+    public function testMultipleObservers()
+    {
+        $spy1 = new ObserverSpy([DatabaseEventTypeEnum::BEFORE_EXECUTE]);
+        $spy2 = new ObserverSpy([DatabaseEventTypeEnum::AFTER_EXECUTE]);
+        $this->executor->addObserver($spy1);
+        $this->executor->addObserver($spy2);
+
+        $this->executor->execute("insert into users (name) values ('John')");
+
+        $this->assertEquals([DatabaseEventTypeEnum::BEFORE_EXECUTE], $spy1->eventTypes());
+        $this->assertEquals([DatabaseEventTypeEnum::AFTER_EXECUTE], $spy2->eventTypes());
+    }
+}

--- a/tests/JournalTest.php
+++ b/tests/JournalTest.php
@@ -1,0 +1,409 @@
+<?php
+
+namespace Test;
+
+use ByJG\AnyDataset\Db\DatabaseExecutor;
+use ByJG\AnyDataset\Db\Exception\JournalException;
+use ByJG\AnyDataset\Db\Factory;
+use ByJG\AnyDataset\Db\Interfaces\DbDriverInterface;
+use ByJG\AnyDataset\Db\Journal\JournalOperationEnum;
+use ByJG\AnyDataset\Db\Journal\JournalRecorder;
+use ByJG\AnyDataset\Db\Journal\JournalRestorer;
+use Override;
+use PHPUnit\Framework\TestCase;
+
+class JournalTest extends TestCase
+{
+    protected DbDriverInterface $dbDriver;
+
+    protected DatabaseExecutor $executor;
+
+    protected string $dbFile = '/tmp/journal_test.db';
+
+    #[Override]
+    public function setUp(): void
+    {
+        $this->dbDriver = Factory::getDbInstance('sqlite://' . $this->dbFile);
+        $this->executor = DatabaseExecutor::using($this->dbDriver);
+
+        $this->executor->execute(
+            'create table users (
+            id integer primary key autoincrement,
+            name varchar(45),
+            createdate datetime);'
+        );
+        $this->executor->execute("insert into users (name, createdate) values ('John Doe', '2017-01-02')");
+        $this->executor->execute("insert into users (name, createdate) values ('Jane Doe', '2017-01-04')");
+        $this->executor->execute("insert into users (name, createdate) values ('JG', '1974-01-26')");
+
+        $this->executor->execute(
+            'create table info (
+            id integer primary key autoincrement,
+            iduser INTEGER,
+            property varchar(45));'
+        );
+        $this->executor->execute("insert into info (iduser, property) values (1, 'xxx')");
+    }
+
+    #[Override]
+    public function tearDown(): void
+    {
+        unset($this->executor);
+        unset($this->dbDriver);
+        if (file_exists($this->dbFile)) {
+            unlink($this->dbFile);
+        }
+    }
+
+    protected function fetchAll(string $table): array
+    {
+        $result = [];
+        foreach ($this->executor->getIterator("select * from $table order by id") as $row) {
+            $result[] = $row->toArray();
+        }
+        return $result;
+    }
+
+    public function testRecordInsert()
+    {
+        $recorder = JournalRecorder::forAllTables();
+        $this->executor->addObserver($recorder);
+
+        $this->executor->execute(
+            "insert into users (name, createdate) values (:name, :createdate)",
+            ['name' => 'New User', 'createdate' => '2020-05-05']
+        );
+
+        $this->assertEquals(1, $recorder->count());
+        $entry = $recorder->getEntries()[0];
+        $this->assertEquals(JournalOperationEnum::INSERT, $entry->getOperation());
+        $this->assertEquals('users', $entry->getTable());
+        $this->assertEquals([], $entry->getOldRows());
+        $this->assertCount(1, $entry->getNewRows());
+        $this->assertEquals('New User', $entry->getNewRows()[0]['name']);
+        $this->assertEquals('2020-05-05', $entry->getNewRows()[0]['createdate']);
+        $this->assertEquals(4, $entry->getNewRows()[0]['id']);
+    }
+
+    public function testRecordUpdate()
+    {
+        $recorder = JournalRecorder::forAllTables();
+        $this->executor->addObserver($recorder);
+
+        $this->executor->execute(
+            "update users set name = :name where id = :id",
+            ['name' => 'John Doe Jr', 'id' => 1]
+        );
+
+        $this->assertEquals(1, $recorder->count());
+        $entry = $recorder->getEntries()[0];
+        $this->assertEquals(JournalOperationEnum::UPDATE, $entry->getOperation());
+        $this->assertEquals('users', $entry->getTable());
+        $this->assertCount(1, $entry->getOldRows());
+        $this->assertCount(1, $entry->getNewRows());
+        $this->assertEquals('John Doe', $entry->getOldRows()[0]['name']);
+        $this->assertEquals('John Doe Jr', $entry->getNewRows()[0]['name']);
+    }
+
+    public function testRecordUpdateMultipleRows()
+    {
+        $recorder = JournalRecorder::forAllTables();
+        $this->executor->addObserver($recorder);
+
+        $this->executor->execute("update users set name = 'Anonymous'");
+
+        $entry = $recorder->getEntries()[0];
+        $this->assertCount(3, $entry->getOldRows());
+        $this->assertCount(3, $entry->getNewRows());
+        $this->assertEquals(['John Doe', 'Jane Doe', 'JG'], array_column($entry->getOldRows(), 'name'));
+        $this->assertEquals(['Anonymous', 'Anonymous', 'Anonymous'], array_column($entry->getNewRows(), 'name'));
+    }
+
+    public function testRecordUpdateWhereClauseChangesUpdatedColumn()
+    {
+        $recorder = JournalRecorder::forAllTables();
+        $this->executor->addObserver($recorder);
+
+        // The WHERE clause references the column being changed;
+        // the new values must still be captured (selected by primary key).
+        $this->executor->execute(
+            "update users set name = :newname where name = :oldname",
+            ['newname' => 'Johnny', 'oldname' => 'John Doe']
+        );
+
+        $entry = $recorder->getEntries()[0];
+        $this->assertEquals('John Doe', $entry->getOldRows()[0]['name']);
+        $this->assertEquals('Johnny', $entry->getNewRows()[0]['name']);
+    }
+
+    public function testRecordDelete()
+    {
+        $recorder = JournalRecorder::forAllTables();
+        $this->executor->addObserver($recorder);
+
+        $this->executor->execute("delete from users where id = :id", ['id' => 2]);
+
+        $this->assertEquals(1, $recorder->count());
+        $entry = $recorder->getEntries()[0];
+        $this->assertEquals(JournalOperationEnum::DELETE, $entry->getOperation());
+        $this->assertCount(1, $entry->getOldRows());
+        $this->assertEquals('Jane Doe', $entry->getOldRows()[0]['name']);
+        $this->assertEquals([], $entry->getNewRows());
+    }
+
+    public function testWatchSingleTable()
+    {
+        $recorder = JournalRecorder::forTables('info');
+        $this->executor->addObserver($recorder);
+
+        $this->executor->execute("insert into users (name) values ('Ignored')");
+        $this->executor->execute("insert into info (iduser, property) values (2, 'yyy')");
+
+        $this->assertEquals(1, $recorder->count());
+        $this->assertEquals('info', $recorder->getEntries()[0]->getTable());
+    }
+
+    public function testNonDmlStatementsAreIgnored()
+    {
+        $recorder = JournalRecorder::forAllTables();
+        $this->executor->addObserver($recorder);
+
+        $this->executor->execute("create table temp_table (id integer primary key)");
+        $this->executor->getIterator("select * from users");
+        $this->executor->execute("drop table temp_table");
+
+        $this->assertEquals(0, $recorder->count());
+    }
+
+    public function testExecuteAndGetIdIsRecorded()
+    {
+        $recorder = JournalRecorder::forAllTables();
+        $this->executor->addObserver($recorder);
+
+        $id = $this->executor->executeAndGetId(
+            "insert into users (name, createdate) values (:name, :createdate)",
+            ['name' => 'New User', 'createdate' => '2020-05-05']
+        );
+
+        $this->assertEquals(4, $id);
+        $this->assertEquals(1, $recorder->count());
+        $this->assertEquals(4, $recorder->getEntries()[0]->getNewRows()[0]['id']);
+    }
+
+    public function testRestoreAfterMixedOperations()
+    {
+        $before = [
+            'users' => $this->fetchAll('users'),
+            'info' => $this->fetchAll('info'),
+        ];
+
+        $recorder = JournalRecorder::forAllTables();
+        $this->executor->addObserver($recorder);
+
+        // Simulate the functional test body
+        $this->executor->execute("insert into users (name, createdate) values ('Temp User', '2021-01-01')");
+        $this->executor->execute("update users set name = :name where id = :id", ['name' => 'Changed', 'id' => 1]);
+        $this->executor->execute("delete from users where id = :id", ['id' => 2]);
+        $this->executor->execute("insert into info (iduser, property) values (9, 'to-be-removed')");
+        $this->executor->execute("update info set property = 'zzz' where id = 1");
+
+        $this->assertEquals(5, $recorder->count());
+        $this->assertNotEquals($before['users'], $this->fetchAll('users'));
+        $this->assertNotEquals($before['info'], $this->fetchAll('info'));
+
+        // Simulate tearDown
+        $this->executor->removeObserver($recorder);
+        (new JournalRestorer())->restore($this->dbDriver, $recorder);
+
+        $this->assertEquals($before['users'], $this->fetchAll('users'));
+        $this->assertEquals($before['info'], $this->fetchAll('info'));
+        $this->assertEquals(0, $recorder->count());
+    }
+
+    public function testRestoreUpdateOnSameRowMultipleTimes()
+    {
+        $before = $this->fetchAll('users');
+
+        $recorder = JournalRecorder::forAllTables();
+        $this->executor->addObserver($recorder);
+
+        $this->executor->execute("update users set name = 'First Change' where id = 1");
+        $this->executor->execute("update users set name = 'Second Change' where id = 1");
+
+        $this->executor->removeObserver($recorder);
+        (new JournalRestorer())->restore($this->dbDriver, $recorder);
+
+        $this->assertEquals($before, $this->fetchAll('users'));
+    }
+
+    public function testRestoreDeleteReinsertsRowWithSameId()
+    {
+        $before = $this->fetchAll('users');
+
+        $recorder = JournalRecorder::forAllTables();
+        $this->executor->addObserver($recorder);
+
+        $this->executor->execute("delete from users where id = 2");
+
+        $this->executor->removeObserver($recorder);
+        (new JournalRestorer())->restore($this->dbDriver, $recorder);
+
+        $this->assertEquals($before, $this->fetchAll('users'));
+    }
+
+    public function testRestoreKeepsEntriesWhenClearIsFalse()
+    {
+        $recorder = JournalRecorder::forAllTables();
+        $this->executor->addObserver($recorder);
+
+        $this->executor->execute("delete from users where id = 3");
+        $this->executor->removeObserver($recorder);
+
+        (new JournalRestorer())->restore($this->dbDriver, $recorder, clear: false);
+
+        $this->assertEquals(1, $recorder->count());
+    }
+
+    public function testClear()
+    {
+        $recorder = JournalRecorder::forAllTables();
+        $this->executor->addObserver($recorder);
+
+        $this->executor->execute("delete from users where id = 3");
+        $this->assertEquals(1, $recorder->count());
+
+        $recorder->clear();
+        $this->assertEquals(0, $recorder->count());
+        $this->assertEquals([], $recorder->getEntries());
+    }
+
+    public function testInsertWithLiteralValues()
+    {
+        $recorder = JournalRecorder::forAllTables();
+        $this->executor->addObserver($recorder);
+
+        $this->executor->execute("insert into users (name, createdate) values ('Literal User', '2022-02-02')");
+
+        $entry = $recorder->getEntries()[0];
+        $this->assertEquals('Literal User', $entry->getNewRows()[0]['name']);
+        $this->assertEquals('2022-02-02', $entry->getNewRows()[0]['createdate']);
+    }
+
+    public function testCustomPrimaryKey()
+    {
+        $this->executor->execute(
+            'create table products (
+            sku varchar(20) primary key,
+            title varchar(45));'
+        );
+        $this->executor->execute("insert into products (sku, title) values ('ABC', 'Product ABC')");
+
+        $before = $this->fetchAllBy('products', 'sku');
+
+        $recorder = JournalRecorder::forTables('products')
+            ->withPrimaryKey('products', 'sku');
+        $this->executor->addObserver($recorder);
+
+        $this->executor->execute("update products set title = 'Renamed' where sku = 'ABC'");
+        $this->executor->execute(
+            "insert into products (sku, title) values (:sku, :title)",
+            ['sku' => 'XYZ', 'title' => 'Product XYZ']
+        );
+
+        $this->executor->removeObserver($recorder);
+        (new JournalRestorer())->restore($this->dbDriver, $recorder);
+
+        $this->assertEquals($before, $this->fetchAllBy('products', 'sku'));
+    }
+
+    protected function fetchAllBy(string $table, string $orderBy): array
+    {
+        $result = [];
+        foreach ($this->executor->getIterator("select * from $table order by $orderBy") as $row) {
+            $result[] = $row->toArray();
+        }
+        return $result;
+    }
+
+    public function testStrictModeRejectsUnparseableWriteBeforeExecution()
+    {
+        $before = $this->fetchAll('info');
+
+        $recorder = JournalRecorder::forAllTables()->strict();
+        $this->executor->addObserver($recorder);
+
+        try {
+            $this->executor->execute("insert into info (iduser, property) select id, name from users");
+            $this->fail('Expected JournalException was not thrown');
+        } catch (JournalException $ex) {
+            $this->assertStringContainsString('unsupported DML shape', $ex->getMessage());
+        }
+
+        // The statement must have been blocked BEFORE executing
+        $this->assertEquals($before, $this->fetchAll('info'));
+        $this->assertEquals(0, $recorder->count());
+    }
+
+    public function testStrictModeRejectsMultiStatementSql()
+    {
+        $recorder = JournalRecorder::forAllTables()->strict();
+        $this->executor->addObserver($recorder);
+
+        $this->expectException(JournalException::class);
+        $this->executor->execute("delete from users; delete from info");
+    }
+
+    public function testStrictModeAllowsNonWriteStatements()
+    {
+        $recorder = JournalRecorder::forAllTables()->strict();
+        $this->executor->addObserver($recorder);
+
+        $this->executor->execute("create table temp_strict (id integer primary key)");
+        $this->executor->execute("drop table temp_strict");
+
+        $this->assertEquals(0, $recorder->count());
+    }
+
+    public function testStrictModeRecordsSupportedDmlNormally()
+    {
+        $recorder = JournalRecorder::forAllTables()->strict();
+        $this->executor->addObserver($recorder);
+
+        $this->executor->execute("insert into users (name) values ('Strict User')");
+        $this->executor->execute("update users set name = 'Changed' where id = 1");
+        $this->executor->execute("delete from users where id = 2");
+
+        $this->assertEquals(3, $recorder->count());
+    }
+
+    public function testStrictModeRejectsInsertWithUncapturableValues()
+    {
+        $this->executor->execute(
+            'create table products (
+            sku varchar(20) primary key,
+            title varchar(45));'
+        );
+
+        $recorder = JournalRecorder::forTables('products')
+            ->withPrimaryKey('products', 'sku')
+            ->strict();
+        $this->executor->addObserver($recorder);
+
+        // All values are expressions the parser cannot resolve, and the table
+        // has no usable auto increment id to fetch the row back.
+        $this->expectException(JournalException::class);
+        $this->executor->execute("insert into products (sku, title) values (upper('abc'), upper('product'))");
+    }
+
+    public function testNonStrictModeSkipsUnparseableWriteSilently()
+    {
+        $recorder = JournalRecorder::forAllTables();
+        $this->executor->addObserver($recorder);
+
+        $this->executor->execute("insert into info (iduser, property) select id, name from users");
+
+        // Executed (3 users copied into info), but not journaled
+        $this->assertCount(4, $this->fetchAll('info'));
+        $this->assertEquals(0, $recorder->count());
+    }
+}


### PR DESCRIPTION
## Summary

Backward-compatible feature release (proposed as **6.1.0**).

### Executor Observers
- New `DatabaseEventObserverInterface`, attachable with `DatabaseExecutor::addObserver()` / `removeObserver()`
- Events: `BEFORE_QUERY`, `AFTER_QUERY`, `BEFORE_EXECUTE`, `AFTER_EXECUTE` (`DatabaseEventTypeEnum`), each carrying a `DatabaseEvent` with the `SqlStatement`, the executor and the result
- Enables decoupled auditing, metrics and query logging
- **No overhead when no observer is attached**: benchmarked 20k writes + 20k queries against the previous executor — difference within run-to-run noise (the event object is only allocated per subscribed observer)

### Journal (record and restore DML changes)
Built on top of the observer interface, records all INSERT/UPDATE/DELETE with row values **before and after** each operation:
- `JournalRecorder::forAllTables()` / `::forTables(...)`, configurable primary keys
- `JournalRestorer` replays the journal in reverse (deletes inserts, writes back old values, re-inserts deletes) — designed for functional test setUp/tearDown
- Optional **strict mode** (`->strict()`): throws `JournalException` on statements that cannot be journaled/restored (unparseable DML blocked *before* execution) instead of skipping silently

### Docs & changelog
- New pages: `docs/observers.md`, `docs/journal.md` (limitations documented, including that deprecated driver methods bypass observers)
- `CHANGELOG-6.1.md` added; README index updated

## Testing
- 28 new tests (observer event firing/filtering/removal; journal recording, restore round-trips, custom PKs, strict mode)
- Full suite: 711 tests passing against SQLite, MySQL and PostgreSQL; Psalm clean
- The only failures in the local run are the 62 pre-existing MSSQL connection errors (SQL Server container crashes on the local host — unrelated to this change)